### PR TITLE
Use Java 11 in github build action

### DIFF
--- a/.github/workflows/build_bridgelink.yml
+++ b/.github/workflows/build_bridgelink.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '8'
+          java-version: '11'
           java-package: 'jdk+fx'
           distribution: 'zulu'
 

--- a/.github/workflows/build_bridgelink.yml
+++ b/.github/workflows/build_bridgelink.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - bridgelink_development
+      # TODO: testing only
+      - fix_github_ant_build
   pull_request:
     branches:
       - bridgelink_development


### PR DESCRIPTION
The latest changes do not compile on Java8 anymore.

This configures the github action to use java 11 for compilation.