### PR TITLE
Bugfix: Fix crash while calling LookupHelper.getMatching() on SQLServer

### DIFF
--- a/custom-extensions/dynamic-lookup-gateway/server/src/main/resources/mapper/sqlserver-lookup.xml
+++ b/custom-extensions/dynamic-lookup-gateway/server/src/main/resources/mapper/sqlserver-lookup.xml
@@ -106,7 +106,7 @@
     <select id="getMatchingLookupValues" parameterType="map" resultMap="lookup-value">
         SELECT KEY_VALUE, VALUE_DATA
         FROM ${tableName}
-        WHERE LOWER(KEY_VALUE) LIKE LOWER('%' || #{keyPattern} || '%')
+        WHERE LOWER(KEY_VALUE) LIKE LOWER('%' + #{keyPattern} + '%')
     </select>
 
     <select id="getValue" parameterType="map" resultType="String">


### PR DESCRIPTION
Just found while testing. The underlying function getMatchingLookupValues() uses wrong string concat operators for the like search.  