### PR TITLE
bugfix:Change to getSqlSessionManager in DefaultConfigurationController

### DIFF
--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -990,12 +990,12 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
         try {
             List<KeyValuePair> result;
             if (CollectionUtils.isEmpty(propertyKeys)) {
-                result = SqlConfig.getInstance().getReadOnlySqlSessionManager().selectList("Configuration.selectPropertiesForCategory", category);
+                result = SqlConfig.getInstance().getSqlSessionManager().selectList("Configuration.selectPropertiesForCategory", category);
             } else {
                 Map<String, Object> parameterMap = new HashMap<>();
                 parameterMap.put("category", category);
                 parameterMap.put("propertyKeys", propertyKeys);
-                result = SqlConfig.getInstance().getReadOnlySqlSessionManager().selectList("Configuration.selectFilteredPropertiesForCategory", parameterMap);
+                result = SqlConfig.getInstance().getSqlSessionManager().selectList("Configuration.selectFilteredPropertiesForCategory", parameterMap);
             }
 
             for (KeyValuePair pair : result) {
@@ -1034,7 +1034,7 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
             Map<String, Object> parameterMap = new HashMap<String, Object>();
             parameterMap.put("category", category);
             parameterMap.put("name", name);
-            return (String) SqlConfig.getInstance().getReadOnlySqlSessionManager().selectOne("Configuration.selectProperty", parameterMap);
+            return (String) SqlConfig.getInstance().getSqlSessionManager().selectOne("Configuration.selectProperty", parameterMap);
         } catch (Exception e) {
             logger.error("Could not retrieve property: category=" + category + ", name=" + name, e);
         } finally {
@@ -1581,7 +1581,7 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
     private boolean testDatabase(boolean readOnly) {
         Statement statement = null;
         Connection connection = null;
-        SqlSessionManager manager = (readOnly ? SqlConfig.getInstance().getReadOnlySqlSessionManager() : SqlConfig.getInstance().getSqlSessionManager());
+        SqlSessionManager manager = (readOnly ? SqlConfig.getInstance().getSqlSessionManager() : SqlConfig.getInstance().getSqlSessionManager());
         manager.startManagedSession();
 
         try {


### PR DESCRIPTION
bugfix:Change to getSqlSessionManager in DefaultConfigurationControllerer getProperty/getPropertiesForGroup
This pull request updates how database sessions are managed in the `DefaultConfigurationController` by removing the use of the read-only SQL session manager and standardizing on the regular SQL session manager for all property retrieval and database test operations.

**Database session management:**

* Replaced usage of `getReadOnlySqlSessionManager()` with `getSqlSessionManager()` in the `getPropertiesForGroup`, `getProperty`, and `testDatabase` methods in `DefaultConfigurationController.java`, ensuring all database operations use the same session manager. [[1]](diffhunk://#diff-701e61280925f72e7aa0d81c51b69165e0f03f08a80cc55a6cc80a573944d7cdL993-R998) [[2]](diffhunk://#diff-701e61280925f72e7aa0d81c51b69165e0f03f08a80cc55a6cc80a573944d7cdL1037-R1037) [[3]](diffhunk://#diff-701e61280925f72e7aa0d81c51b69165e0f03f08a80cc55a6cc80a573944d7cdL1584-R1584)