### PR TITLE
Security upgrade: root/admin guard, no_new_privs advisory, keystore hardening, Jetty 12, SMTP OAuth

### DIFF
--- a/custom-extensions/dynamic-lookup-gateway/plugin.xml
+++ b/custom-extensions/dynamic-lookup-gateway/plugin.xml
@@ -3,7 +3,7 @@
     <name>Lookup Table Management System</name>
     <author>Daniel Svanstedt, Thai Tran</author>
     <pluginVersion>2.1.0</pluginVersion>
-    <mirthVersion>4.5.3, 4.5.4, 4.5.5, 4.6.0, 4.6.1, 26.3.1</mirthVersion>
+    <mirthVersion>4.5.3, 4.5.4, 4.5.5, 4.6.0, 4.6.1, 26.3.0, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>This plugin provides a centralized repository for key-value pairs used across channel</description>
     <clientClasses>

--- a/custom-extensions/dynamic-lookup-gateway/plugin.xml
+++ b/custom-extensions/dynamic-lookup-gateway/plugin.xml
@@ -3,7 +3,7 @@
     <name>Lookup Table Management System</name>
     <author>Daniel Svanstedt, Thai Tran</author>
     <pluginVersion>2.1.0</pluginVersion>
-    <mirthVersion>4.5.3, 4.5.4, 4.5.5, 4.6.0, 4.6.1, 26.3.0</mirthVersion>
+    <mirthVersion>4.5.3, 4.5.4, 4.5.5, 4.6.0, 4.6.1, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>This plugin provides a centralized repository for key-value pairs used across channel</description>
     <clientClasses>

--- a/custom-extensions/message-trends/plugin.xml
+++ b/custom-extensions/message-trends/plugin.xml
@@ -3,7 +3,7 @@
     <name>Message Trends Management System</name>
     <author>Daniel Svanstedt, Thai Tran</author>
     <pluginVersion>1.0.0</pluginVersion>
-    <mirthVersion>4.5.4, 4.6.0, 4.6.1, 26.3.0</mirthVersion>
+    <mirthVersion>4.5.4, 4.6.0, 4.6.1, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>This plugin provides time-series message statistics tracking and visualization</description>
     <clientClasses>

--- a/custom-extensions/message-trends/plugin.xml
+++ b/custom-extensions/message-trends/plugin.xml
@@ -3,7 +3,7 @@
     <name>Message Trends Management System</name>
     <author>Daniel Svanstedt, Thai Tran</author>
     <pluginVersion>1.0.0</pluginVersion>
-    <mirthVersion>4.5.4, 4.6.0, 4.6.1, 26.3.1</mirthVersion>
+    <mirthVersion>4.5.4, 4.6.0, 4.6.1, 26.3.0, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>This plugin provides time-series message statistics tracking and visualization</description>
     <clientClasses>

--- a/custom-extensions/version-history/plugin.xml
+++ b/custom-extensions/version-history/plugin.xml
@@ -3,7 +3,7 @@
     <name>Version History Plugin</name>
     <author>Innovar Healthcare</author>
     <pluginVersion>3.0.1</pluginVersion>
-    <mirthVersion>26.3.0, 26.3.1</mirthVersion>
+    <mirthVersion>26.3.1, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>Innovar Healthcare Version History Plugin</description>
     <clientClasses>

--- a/custom-extensions/version-history/plugin.xml
+++ b/custom-extensions/version-history/plugin.xml
@@ -3,7 +3,7 @@
     <name>Version History Plugin</name>
     <author>Innovar Healthcare</author>
     <pluginVersion>3.0.1</pluginVersion>
-    <mirthVersion>26.3.1, 26.3.1</mirthVersion>
+    <mirthVersion>26.3.0, 26.3.1</mirthVersion>
     <url>https://www.innovarhealthcare.com</url>
     <description>Innovar Healthcare Version History Plugin</description>
     <clientClasses>

--- a/server/conf/mirth.properties
+++ b/server/conf/mirth.properties
@@ -27,7 +27,7 @@ password.reuselimit = 0
 password.allowusernameenumeration = false
 
 # Only used for migration purposes, do not modify
-version = 26.3.0
+version = 26.3.1
 
 # keystore
 keystore.path = ${dir.appdata}/keystore.jks

--- a/server/mirth-build.properties
+++ b/server/mirth-build.properties
@@ -5,4 +5,4 @@ webadmin=../webadmin
 manager=../manager
 cli=../command
 custom-extensions=../custom-extensions
-version=26.3.0
+version=26.3.1

--- a/server/setup/conf/mirth.properties
+++ b/server/setup/conf/mirth.properties
@@ -27,7 +27,7 @@ password.reuselimit = 0
 password.allowusernameenumeration = false
 
 # Only used for migration purposes, do not modify
-version = 26.3.0
+version = 26.3.1
 
 # keystore
 keystore.path = ${dir.appdata}/keystore.jks

--- a/server/src/com/mirth/connect/client/core/Version.java
+++ b/server/src/com/mirth/connect/client/core/Version.java
@@ -87,7 +87,8 @@ public enum Version {
     v4_5_4("4.5.4"), //BridgeLink
     v4_6_0("4.6.0"),//BridgeLink
     v4_6_1("4.6.1"), //BridgeLink
-    v26_3_0("26.3.0"); //BridgeLink — SMTP OAuth
+    v26_3_0("26.3.0"), //BridgeLink — SMTP OAuth
+    v26_3_1("26.3.1"); //BridgeLink
     
     // @formatter:on
 

--- a/server/src/com/mirth/connect/connectors/dimse/destination.xml
+++ b/server/src/com/mirth/connect/connectors/dimse/destination.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to send messages using DICOM protocol.</description>
 	<clientClassName>com.mirth.connect.connectors.dimse.DICOMSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/dimse/source.xml
+++ b/server/src/com/mirth/connect/connectors/dimse/source.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to listen for incoming messages over a standard TCP connection.</description>
 	<clientClassName>com.mirth.connect.connectors.dimse.DICOMListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/doc/destination.xml
+++ b/server/src/com/mirth/connect/connectors/doc/destination.xml
@@ -2,7 +2,7 @@
 	<name>Document Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to create RTF or PDF documents based on an HTML template. PDF files can be password protected.</description>
 	<clientClassName>com.mirth.connect.connectors.doc.DocumentWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/file/destination.xml
+++ b/server/src/com/mirth/connect/connectors/file/destination.xml
@@ -2,7 +2,7 @@
 	<name>File Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to write files to a local or network file system. A velocity template is available to dynamically generate files.</description>
 	<clientClassName>com.mirth.connect.connectors.file.FileWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/file/source.xml
+++ b/server/src/com/mirth/connect/connectors/file/source.xml
@@ -2,7 +2,7 @@
 	<name>File Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to poll for files from a local or network file system.</description>
 	<clientClassName>com.mirth.connect.connectors.file.FileReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/http/destination.xml
+++ b/server/src/com/mirth/connect/connectors/http/destination.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to send messages to an HTTP server. Custom header properties can be specified.</description>
 	<clientClassName>com.mirth.connect.connectors.http.HttpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/http/source.xml
+++ b/server/src/com/mirth/connect/connectors/http/source.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to listen for incoming HTTP data. Messages are received as XML and include the full header contents.</description>
 	<clientClassName>com.mirth.connect.connectors.http.HttpListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jdbc/destination.xml
+++ b/server/src/com/mirth/connect/connectors/jdbc/destination.xml
@@ -2,7 +2,7 @@
 	<name>Database Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to write to any JDBC-compatabile database with Insert, Update or JavaScript statements.</description>
 	<clientClassName>com.mirth.connect.connectors.jdbc.DatabaseWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jdbc/source.xml
+++ b/server/src/com/mirth/connect/connectors/jdbc/source.xml
@@ -2,7 +2,7 @@
 	<name>Database Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to poll any supported JDBC-compatabile database for data. Rows are returned as XML and JavaScript can be used for advanced logic.</description>
 	<clientClassName>com.mirth.connect.connectors.jdbc.DatabaseReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jms/destination.xml
+++ b/server/src/com/mirth/connect/connectors/jms/destination.xml
@@ -2,7 +2,7 @@
 	<name>JMS Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to write messages to a JMS queue.</description>
 	<clientClassName>com.mirth.connect.connectors.jms.JmsSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/jms/source.xml
+++ b/server/src/com/mirth/connect/connectors/jms/source.xml
@@ -2,7 +2,7 @@
 	<name>JMS Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to read messages from a JMS queue.</description>
 	<clientClassName>com.mirth.connect.connectors.jms.JmsListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/js/destination.xml
+++ b/server/src/com/mirth/connect/connectors/js/destination.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to execute JavaScript to connect to an arbitrary destination.</description>
 	<clientClassName>com.mirth.connect.connectors.js.JavaScriptWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/js/source.xml
+++ b/server/src/com/mirth/connect/connectors/js/source.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to execute arbitrary JavaScript to pull in messages to a channel.</description>
 	<clientClassName>com.mirth.connect.connectors.js.JavaScriptReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/smtp/destination.xml
+++ b/server/src/com/mirth/connect/connectors/smtp/destination.xml
@@ -2,7 +2,7 @@
 	<name>SMTP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to send email messages via SMTP. A template is available to dynamically create messages.</description>
 	<clientClassName>com.mirth.connect.connectors.smtp.SmtpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/tcp/destination.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/destination.xml
@@ -2,7 +2,7 @@
 	<name>TCP Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to send messages to a TCP server.</description>
 	<clientClassName>com.mirth.connect.connectors.tcp.TcpSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/tcp/plugin.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/plugin.xml
@@ -2,7 +2,7 @@
 	<name>TCP Connector Service Plugin</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin is required for correct use of the TCP connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/connectors/tcp/source.xml
+++ b/server/src/com/mirth/connect/connectors/tcp/source.xml
@@ -2,7 +2,7 @@
 	<name>TCP Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to listen for incoming messages over a standard TCP connection.</description>
 	<clientClassName>com.mirth.connect.connectors.tcp.TcpListener</clientClassName>

--- a/server/src/com/mirth/connect/connectors/vm/destination.xml
+++ b/server/src/com/mirth/connect/connectors/vm/destination.xml
@@ -2,7 +2,7 @@
 	<name>Channel Writer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to send events to other channels in the same Mirth Connect instance.</description>
 	<clientClassName>com.mirth.connect.connectors.vm.ChannelWriter</clientClassName>

--- a/server/src/com/mirth/connect/connectors/vm/source.xml
+++ b/server/src/com/mirth/connect/connectors/vm/source.xml
@@ -2,7 +2,7 @@
 	<name>Channel Reader</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to listen for incoming events from other channels in the same Mirth Connect instance.</description>
 	<clientClassName>com.mirth.connect.connectors.vm.ChannelReader</clientClassName>

--- a/server/src/com/mirth/connect/connectors/ws/destination.xml
+++ b/server/src/com/mirth/connect/connectors/ws/destination.xml
@@ -2,7 +2,7 @@
 	<name>Web Service Sender</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to invoke remote Web Services over HTTP.</description>
 	<clientClassName>com.mirth.connect.connectors.ws.WebServiceSender</clientClassName>

--- a/server/src/com/mirth/connect/connectors/ws/source.xml
+++ b/server/src/com/mirth/connect/connectors/ws/source.xml
@@ -2,7 +2,7 @@
 	<name>Web Service Listener</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This connector allows Mirth Connect to listen on an HTTP port for incoming Web Service calls. This connector also provides a WSDL for SOAP clients to use.</description>
 	<clientClassName>com.mirth.connect.connectors.ws.WebServiceListener</clientClassName>

--- a/server/src/com/mirth/connect/plugins/dashboardstatus/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/dashboardstatus/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Dashboard Connector Status Monitor</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a real-time connection status column on the Mirth Connect client</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datapruner/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datapruner/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Data Pruner</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides data pruning capability for Mirth Connect</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/delimited/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/delimited/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Delimited Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the delimited data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/dicom/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/dicom/plugin.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the DICOM data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/edi/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/edi/plugin.xml
@@ -2,7 +2,7 @@
 	<name>EDI Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the EDI data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/hl7v2/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/hl7v2/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HL7v2 Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the HL7v2 data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/hl7v3/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/hl7v3/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HL7v3 Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the HL7v3 data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/json/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/json/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JSON Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the JSON data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/ncpdp/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/ncpdp/plugin.xml
@@ -2,7 +2,7 @@
 	<name>NCPDP Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the NCPDP data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/raw/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/raw/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Raw Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the raw data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/datatypes/xml/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/datatypes/xml/plugin.xml
@@ -2,7 +2,7 @@
 	<name>XML Data Type</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides support for the XML data type</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/destinationsetfilter/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/destinationsetfilter/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Destination Set Filter Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>Provides an easy method in the source transformer to filter destinations from being executed.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/dicomviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/dicomviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>DICOM Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides DICOM attachment viewing capability in message browser</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/directoryresource/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/directoryresource/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Directory Resource Plugin</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin allows a directory to be used as a source for libraries to include in channels.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/globalmapviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/globalmapviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Global Map Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin allows you to view the global map and global channel maps in the Mirth Connect Administrator.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/httpauth/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/httpauth/plugin.xml
@@ -2,7 +2,7 @@
 	<name>HTTP Authentication Settings</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides advanced authentication support for HTTP-based source connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/imageviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/imageviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Image Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides image attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/javascriptrule/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/javascriptrule/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Filter Rule</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a JavaScript rule-type for Mirth Connect filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/javascriptstep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/javascriptstep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>JavaScript Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a JavaScript step-type for Mirth Connect transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/mapper/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/mapper/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Mapper Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a Mapping step type for Mirth Connect transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/messagebuilder/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/messagebuilder/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Message Builder Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a Message Builder step-type for Mirth Connect transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/mllpmode/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/mllpmode/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Transmission Mode - MLLP</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides an MLLP transmission mode for socket/serial connectors.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/pdfviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/pdfviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>PDF Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides PDF attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/rulebuilder/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/rulebuilder/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Rule Builder Filter Rule</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a Rule Builder type for Mirth Connect filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/scriptfilerule/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/scriptfilerule/plugin.xml
@@ -2,7 +2,7 @@
 	<name>External Script Filter Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides an External Script step-type for Mirth Connect filters</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/scriptfilestep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/scriptfilestep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>External Script Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides an External Script step-type for Mirth Connect transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/serverlog/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/serverlog/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Server Log</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin allows you to view the server log on the Mirth Connect administrator.</description>
 	<serverClasses>

--- a/server/src/com/mirth/connect/plugins/textviewer/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/textviewer/plugin.xml
@@ -2,7 +2,7 @@
 	<name>Text Viewer</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides text and RTF attachment viewing capability in message browser.</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/plugins/xsltstep/plugin.xml
+++ b/server/src/com/mirth/connect/plugins/xsltstep/plugin.xml
@@ -2,7 +2,7 @@
 	<name>XSLT Transformer Step</name>
 	<author>NextGen Healthcare</author>
 	<pluginVersion>@mirthversion</pluginVersion>
-	<mirthVersion>26.3.0</mirthVersion>
+	<mirthVersion>26.3.1</mirthVersion>
 	<url>http://www.nextgen.com</url>
 	<description>This plugin provides a XSLT support step-type for Mirth Connect transformers</description>
 	<clientClasses>

--- a/server/src/com/mirth/connect/server/Mirth.java
+++ b/server/src/com/mirth/connect/server/Mirth.java
@@ -214,8 +214,6 @@ public class Mirth extends Thread {
                     int value = Integer.parseInt(line.substring("NoNewPrivs:".length()).trim());
                     if (value == 0) {
                         logger.warn(NO_NEW_PRIVS_WARNING);
-                    } else {
-                        logger.info("no_new_privs is active — kernel-level privilege escalation (sudo/SUID) is blocked.");
                     }
                     return;
                 }

--- a/server/src/com/mirth/connect/server/Mirth.java
+++ b/server/src/com/mirth/connect/server/Mirth.java
@@ -203,8 +203,6 @@ public class Mirth extends Thread {
             System.exit(1);
         } else if (result == RootCheckResult.WARN) {
             logger.warn("BridgeLink is running as root/Administrator. server.allowRoot=true is set — proceeding.");
-        } else {
-            logger.info("Privilege check passed: running as user '" + userName + "' (not root/Administrator).");
         }
     }
 

--- a/server/src/com/mirth/connect/server/migration/Migrate26_3_1.java
+++ b/server/src/com/mirth/connect/server/migration/Migrate26_3_1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Innovar Healthcare. All rights reserved
+ * This project is a fork of Mirth Connect by Nextgen Healthcare.
+ * It has been modified and maintained independently by Innovar Healthcare.
+ */
+
+package com.mirth.connect.server.migration;
+
+import com.mirth.connect.model.util.MigrationException;
+
+public class Migrate26_3_1 extends Migrator {
+
+    @Override
+    public void migrate() throws MigrationException {
+        // No database schema changes required for 26.3.1
+    }
+
+    @Override
+    public void migrateSerializedData() throws MigrationException {
+        // No serialized data migration required for 26.3.1
+    }
+}

--- a/server/src/com/mirth/connect/server/migration/ServerMigrator.java
+++ b/server/src/com/mirth/connect/server/migration/ServerMigrator.java
@@ -247,6 +247,7 @@ public class ServerMigrator extends com.mirth.connect.server.migration.Migrator 
             case v4_6_0: return new com.mirth.connect.server.migration.Migrate4_6_0();
             case v4_6_1: return null;
             case v26_3_0: return new com.mirth.connect.server.migration.Migrate26_3_0();
+            case v26_3_1: return null;
         } // @formatter:on
 
         return null;


### PR DESCRIPTION
## Summary

- **Root/admin startup guard**: BridgeLink now blocks startup when running as root or Administrator; `server.allowRoot=true` in `mirth.properties` allows override with a warning
- **no_new_privs advisory**: on Linux, reads `/proc/self/status` and warns if `NoNewPrivileges` is not set (privilege escalation risk via sudo/SUID)
- **Privilege check logging cleanup**: suppress info log for the passing (non-root) case — only warn when running as root/Administrator
- **Keystore hardening**: default password detection, warning dialog, and regeneration API (IRT-577); secure password policy defaults in `mirth.properties` (IRT-576)
- **Jetty 12 migration**: full migration including SMTP OAuth, HTTP auth fix, version history plugin, and build improvements
- **Java 17 toolchain**: upgrade toolchain declarations and javac tasks from Java 8 → Java 17
- **Custom extension compatibility**: restore 26.3.0 to `mirthVersion` compatibility lists; untrack `.planning` docs from git
- **Version bump**: 26.3.1

## Test plan

- [ ] Start BridgeLink as a normal user — no privilege log output at startup
- [ ] Start BridgeLink as root with `server.allowRoot=false` (default) — server exits with error
- [ ] Start BridgeLink as root with `server.allowRoot=true` — server starts with warning logged
- [ ] On Linux: verify warn log appears when `NoNewPrivileges=0` in `/proc/self/status`
- [ ] Keystore with default password triggers warning dialog on login
- [ ] SMTP OAuth (Azure/M365) sends test email successfully
- [ ] Custom extensions (dynamic-lookup-gateway, message-trends, version-history) load correctly after upgrade