### PR TITLE
fix(security): close #93 — FIPS-compatible RPM packaging spec (SEC-01)

### DIFF
--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,90 @@
+<!--
+Copyright (c) 2026 Innovar Healthcare
+Licensed under the MPL-1.1.
+-->
+
+# BridgeLink RPM Packaging
+
+This directory holds `bridgelink.spec`, the RPM spec for BridgeLink. It closes
+issue [#93](https://github.com/Innovar-Healthcare/BridgeLink/issues/93): on
+FIPS-mode RHEL 8/9 and AlmaLinux 9 hosts, RPMs built with the historical RPM
+default (MD5 cpio file digests) are rejected by the kernel with `cpio: Digest
+mismatch`. The spec declares `%global _binary_filedigest_algorithm 8` and
+`%global _source_filedigest_algorithm 8` in the spec body itself (so the
+build is reproducible regardless of `~/.rpmmacros` on the build host), which
+selects SHA-256 (algorithm `8`) for both binary and source payload digests.
+
+Maintainer: Innovar Healthcare.
+
+Wiring `rpmbuild` into `.github/workflows/build_bridgelink.yml` is out of
+scope for this milestone — see the "Out of scope" section below.
+
+## Build recipe (Docker, AlmaLinux 9)
+
+```bash
+# 1. Produce the source tarball expected by Source0. CI emits bridgelink.tar.gz
+#    without a version suffix; rename it so rpmbuild's %setup macro finds it.
+cp bridgelink.tar.gz bridgelink-26.3.1.tar.gz
+
+# 2. Build the RPM inside a clean AlmaLinux 9 container.
+docker run --rm -v "$PWD":/work -w /work almalinux:9 bash -c '
+  dnf install -y rpm-build rpmdevtools tar gzip && \
+  rpmdev-setuptree && \
+  cp bridgelink-26.3.1.tar.gz ~/rpmbuild/SOURCES/ && \
+  cp packaging/bridgelink.spec ~/rpmbuild/SPECS/ && \
+  rpmbuild -bb ~/rpmbuild/SPECS/bridgelink.spec && \
+  cp ~/rpmbuild/RPMS/noarch/bridgelink-*.rpm /work/
+'
+```
+
+The output artifact is `bridgelink-26.3.1-1.el9.noarch.rpm` (or similar
+distribution tag) in the repo root.
+
+## FIPS digest verification
+
+```bash
+rpm -qp --qf "FILEDIGESTALGO=%{FILEDIGESTALGO}\n" bridgelink-26.3.1-1.*.noarch.rpm
+```
+
+Expected output: `FILEDIGESTALGO=8` (SHA-256). Reject any other value
+(`1` = MD5). If you see `FILEDIGESTALGO=1` or no output, the `%global`
+directives did not apply — inspect the `rpmbuild` log for `warning:
+%global ignored` and confirm the spec at `packaging/bridgelink.spec` is
+the one rpmbuild consumed.
+
+## GPG signing key audit
+
+```bash
+gpg --list-packets /path/to/innovar-public-signing-key.asc | grep "hash algorithm"
+```
+
+Every line MUST show `hash algorithm: SHA-256` or stronger. Any `SHA-1`
+or `MD5` line means the key has a SHA-1 subkey binding and the key MUST
+be regenerated before signing FIPS-compatible RPMs — RHEL 9's GPG
+verifier rejects signatures whose subkey bindings use SHA-1. This audit
+is a hard pre-merge gate for issue #93. Coordinate with the Innovar
+Healthcare release/security team to obtain the public key for inspection.
+
+## FIPS-mode install test
+
+```bash
+docker run --rm --privileged -v "$PWD":/work almalinux:9 bash -c '
+  fips-mode-setup --enable && \
+  dnf install -y /work/bridgelink-26.3.1-1.noarch.rpm
+'
+```
+
+Expected: install completes with no `cpio: Digest mismatch` error.
+A `Requires: java-17-openjdk-headless` resolution warning in the default
+container repo configuration is acceptable for this digest-only smoke
+test; production installs should run against a repo that provides the
+Java runtime.
+
+The one-shot RHEL 8 hardware install verification is performed
+out-of-band per the milestone's accepted verification matrix.
+
+## Out of scope for this milestone
+
+- Wiring `rpmbuild` into `.github/workflows/` — follow-up.
+- Service definition (systemd unit) — separate issue.
+- WebDAV / commons-httpclient removal — tracked as SEC-V2-01.

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,6 +1,6 @@
 <!--
 Copyright (c) 2026 Innovar Healthcare
-Licensed under the MPL-1.1.
+Licensed under the MPL-2.0.
 -->
 
 # BridgeLink RPM Packaging

--- a/packaging/bridgelink.spec
+++ b/packaging/bridgelink.spec
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Innovar Healthcare
+# Licensed under the MPL-1.1.
+# BridgeLink RPM spec — FIPS-compatible (SHA-256 file digests). Closes #93. See packaging/README.md.
+
+%global _binary_filedigest_algorithm 8
+%global _source_filedigest_algorithm 8
+%global _binary_payload_flags 0x1
+
+Name:           bridgelink
+Version:        26.3.1
+Release:        1%{?dist}
+Summary:        BridgeLink healthcare integration engine
+License:        MPL-1.1
+URL:            https://github.com/Innovar-Healthcare/BridgeLink
+Source0:        bridgelink-%{version}.tar.gz
+BuildArch:      noarch
+BuildRequires:  tar
+BuildRequires:  gzip
+Requires:       java-17-openjdk-headless
+
+%description
+BridgeLink is a fork of NextGen Connect (Mirth Connect) — a healthcare
+integration engine maintained by Innovar Healthcare. This RPM lays down
+the server installation tree under /opt/bridgelink. Service management
+(systemd unit, start scripts) is intentionally out of scope for this
+initial FIPS-digest packaging fix.
+
+%prep
+%setup -q -n bridgelink
+
+%install
+mkdir -p %{buildroot}/opt/bridgelink
+cp -r * %{buildroot}/opt/bridgelink/
+
+%files
+/opt/bridgelink
+
+%changelog
+* Wed May 13 2026 Innovar Healthcare <ossteam@innovarhealthcare.com> - 26.3.1-1
+- Initial RPM packaging with SHA-256 file digests for FIPS compatibility (closes #93)

--- a/packaging/bridgelink.spec
+++ b/packaging/bridgelink.spec
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 Innovar Healthcare
-# Licensed under the MPL-1.1.
+# Licensed under the MPL-2.0.
 # BridgeLink RPM spec — FIPS-compatible (SHA-256 file digests). Closes #93. See packaging/README.md.
 
 %global _binary_filedigest_algorithm 8
@@ -10,7 +10,7 @@ Name:           bridgelink
 Version:        26.3.1
 Release:        1%{?dist}
 Summary:        BridgeLink healthcare integration engine
-License:        MPL-1.1
+License:        MPL-2.0
 URL:            https://github.com/Innovar-Healthcare/BridgeLink
 Source0:        bridgelink-%{version}.tar.gz
 BuildArch:      noarch

--- a/packaging/bridgelink.spec
+++ b/packaging/bridgelink.spec
@@ -33,6 +33,7 @@ mkdir -p %{buildroot}/opt/bridgelink
 cp -r * %{buildroot}/opt/bridgelink/
 
 %files
+%defattr(-,root,root,-)
 /opt/bridgelink
 
 %changelog


### PR DESCRIPTION
## Summary

Closes #93.

Commits a new top-level `packaging/bridgelink.spec` setting `%global _binary_filedigest_algorithm 8` and `%global _source_filedigest_algorithm 8` so the cpio payload uses SHA-256 file digests. This is required for installation on FIPS-mode RHEL 8/9 and AlmaLinux 9 — the historical MD5 default is rejected by the FIPS kernel with `cpio: Digest mismatch`.

## Changes

- `packaging/bridgelink.spec` (new) — RPM spec with SHA-256 file digest macros, Java 17 runtime dependency, `/opt/bridgelink` layout, no `%post` hooks.
- `packaging/README.md` (new) — Docker-based build recipe, FIPS digest verification command, GPG signing-key audit command, FIPS-mode install verification recipe.

## Test plan

- [x] Build executed in `almalinux:9` Docker container against `packaging/bridgelink.spec` (using a smoke `bridgelink-26.3.1.tar.gz` containing `server/setup/` contents as a stand-in for the future CI-produced tarball). FILEDIGESTALGO captured from the produced `bridgelink-26.3.1-1.el9.noarch.rpm`:

  ```
  FILEDIGESTALGO=8
  ```

  Per-file digest cross-check (`rpm -qp --dump`) confirms the entries are 64-hex-character SHA-256 hashes, not 32-hex MD5 hashes, e.g. `/opt/bridgelink/conf/mirth.properties 5186 ... 9e62abeee2a93f5178feacadb77786136a69529a20563f23273389690dc316e3 ...`.

- [ ] **GPG signing-key audit (pre-merge gate — Assumption A4).** The Innovar Healthcare public signing key is held outside this repo and was not accessible during the work-cycle that produced this PR. Reviewer must run:

  ```bash
  gpg --list-packets /path/to/innovar-public-signing-key.asc | grep "hash algorithm"
  ```

  Every line MUST show `hash algorithm: SHA-256` or stronger. Any `SHA-1` or `MD5` line means the key must be regenerated before this PR can merge (RHEL 9 GPG verifier rejects SHA-1 subkey bindings). Recipe is documented in `packaging/README.md`.

- [ ] **FIPS-mode RPM install verification on AlmaLinux 9 (pre-merge gate — Docker container).** Recipe in `packaging/README.md`:

  ```bash
  docker run --rm --privileged -v "$PWD":/work almalinux:9 bash -c '
    fips-mode-setup --enable && \
    dnf install -y /work/bridgelink-26.3.1-1.noarch.rpm
  '
  ```

  Expected: no `cpio: Digest mismatch` error. A `Requires: java-17-openjdk-headless` repo-resolution warning in the bare container is acceptable for the digest smoke test.

- [ ] **FIPS-mode RPM install verification on RHEL 8 hardware (pre-merge gate — out-of-band).** Milestone explicitly accepts this as a one-shot hardware test outside CI.

- [ ] Second-set-of-eyes review (milestone constraint — all PRs).

## Pre-merge gates

| Gate | Owner | Status |
|------|-------|--------|
| GPG signing key SHA-1 subkey audit (Assumption A4) | Coordinate with Innovar Healthcare key owner | ⏳ open |
| FIPS-mode RPM install smoke test on AlmaLinux 9 (Docker) | CI / reviewer (recipe in `packaging/README.md`) | ⏳ open |
| FIPS-mode RPM install smoke test on RHEL 8 hardware | Out-of-band one-shot | ⏳ open |

## Out of scope (tracked)

- Wiring `rpmbuild` into `.github/workflows/build_bridgelink.yml` — follow-up.
- Service definition / systemd unit — separate issue.
- WebDAV / `commons-httpclient-3.0.1.jar` runtime removal — SEC-V2-01.



---

## Local test verification (2026-05-13)

Ant 1.10.14 + OpenJDK 17.0.18 + Docker.

- `ant -f server/build.xml compile` — **BUILD SUCCESSFUL** (48s)
- **RPM build inside `almalinux:9` Docker container** — successful:
  ```
  RPM built: RPMS/noarch/bridgelink-26.3.1-1.el9.noarch.rpm
  FILEDIGESTALGO=8
  ```
  Per-file digest spot-check via `rpm -qp --dump`:
  ```
  /opt/bridgelink/conf/mirth.properties 22 ... 28835c9901c7a765912e604139cbf10ae60ac456311b655c0459377fc97da466 0100644 root root ...
  ```
  64-hex-character SHA-256 digest confirmed (not MD5). File ownership `root root` confirmed (`%defattr(-,root,root,-)` fix from WR-07).
- `rpmspec --query --srpm --qf '%{NAME} %{VERSION} %{RELEASE} %{LICENSE}\n' packaging/bridgelink.spec` returns:
  ```
  bridgelink 26.3.1 1.el9 MPL-2.0
  ```
  Confirms CR-02 fix (`License: MPL-2.0` matches root `LICENSE` file content "Mozilla Public License Version 2.0").

The three open pre-merge gates (GPG SHA-1 subkey audit, AlmaLinux 9 FIPS install, RHEL 8 hardware FIPS install) remain open as documented above — the digest-macro itself is now validated end-to-end against a real `rpmbuild` toolchain in a containerised FIPS-target distro.
