### PR TITLE
fix(security): close #140 — migrate constant-only commons-httpclient callers to org.apache.http (SEC-03)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,3 +9,7 @@ We support the current minor version in regards to security updates. Versions ar
 If this is a critical vulnerability that you would like to contact us confidentially, email us here:
  
 ossteam@innovarhealthcare.com
+
+## Known residual dependencies
+
+- `commons-httpclient-3.0.1.jar` remains on the server classpath for `WebDavConnection.java` runtime resolution (Apache Slide WebDAV). Tracked for removal under SEC-V2-01. No other callers reference 3.x APIs as of #140 merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,4 +12,14 @@ ossteam@innovarhealthcare.com
 
 ## Known residual dependencies
 
-- `commons-httpclient-3.0.1.jar` remains on the server classpath for `WebDavConnection.java` runtime resolution (Apache Slide WebDAV). Tracked for removal under SEC-V2-01. No other callers reference 3.x APIs as of #140 merge.
+- `commons-httpclient-3.0.1.jar` remains on the server classpath for runtime
+  resolution of two deferred call sites:
+  - `WebDavConnection.java` (`HttpURL` / `HttpsURL` — blocked on Apache Slide
+    replacement; tracked under SEC-V2-01).
+  - `HTTPUtil.java` (`Header` / `HttpParser` — blocked on `HttpParser.parseHeaders`
+    equivalent in `org.apache.http`; tracked under SEC-V2-01 companion).
+
+  All other constant-only callers (`HttpReceiver.java`, `MirthWebServer.java`,
+  `ConnectServiceUtil.java`) were migrated in #140. The jar carries unfixed
+  CVE-2012-5783, CVE-2014-3577, and CVE-2015-5262 (MITM / hostname-verification);
+  exposure is bounded to the two WebDAV/HTTP utility call sites above.

--- a/server/src/com/mirth/connect/client/core/ConnectServiceUtil.java
+++ b/server/src/com/mirth/connect/client/core/ConnectServiceUtil.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;

--- a/server/src/com/mirth/connect/connectors/file/filesystems/WebDavConnection.java
+++ b/server/src/com/mirth/connect/connectors/file/filesystems/WebDavConnection.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+// TODO: migrate to Sardine; blocked by Apache Slide dependency (SEC-V2-01)
 import org.apache.commons.httpclient.HttpURL;
 import org.apache.commons.httpclient.HttpsURL;
 import org.apache.commons.io.filefilter.WildcardFileFilter;

--- a/server/src/com/mirth/connect/connectors/http/HttpReceiver.java
+++ b/server/src/com/mirth/connect/connectors/http/HttpReceiver.java
@@ -72,7 +72,7 @@ import org.eclipse.jetty.security.internal.DefaultUserIdentity;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;

--- a/server/src/com/mirth/connect/server/MirthWebServer.java
+++ b/server/src/com/mirth/connect/server/MirthWebServer.java
@@ -40,7 +40,7 @@ import javax.ws.rs.ext.Provider;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.FalseFileFilter;

--- a/server/src/com/mirth/connect/server/userutil/HTTPUtil.java
+++ b/server/src/com/mirth/connect/server/userutil/HTTPUtil.java
@@ -21,6 +21,7 @@ import javax.mail.util.ByteArrayDataSource;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.fileupload.FileUploadBase;
+// TODO: migrate to org.apache.http; blocked on HttpParser equivalent (SEC-V2-01 companion)
 import org.apache.commons.httpclient.Header;
 import org.apache.commons.httpclient.HttpParser;
 import org.apache.commons.io.IOUtils;


### PR DESCRIPTION
## Summary

Closes #140.

Migrates the three constant-only `commons-httpclient 3.0.1` callers to the already-vendored `org.apache.http` (`httpcore-4.4.13.jar` / `httpclient-4.5.13.jar`). Per CONTEXT.md, `commons-httpclient-3.0.1.jar` STAYS on the classpath because `WebDavConnection.java` still depends on it at runtime (Apache Slide WebDAV). Full WebDAV migration is deferred to SEC-V2-01.

## Changes

- `server/src/com/mirth/connect/connectors/http/HttpReceiver.java` line 75 — import swap. All `HttpStatus.SC_*` usage sites (lines 483, 485, 529, 550, 722, 815) byte-unchanged (constant names identical between 3.x and 4.x).
- `server/src/com/mirth/connect/server/MirthWebServer.java` line 43 — import swap. Usage sites (lines 927, 956, 960) byte-unchanged.
- `server/src/com/mirth/connect/client/core/ConnectServiceUtil.java` line 20 — import swap. Usage sites (lines 79, 115, 173, 224) byte-unchanged. (This file already imported other `org.apache.http.*` classes; the `HttpStatus` import was the lone remaining 3.x reference.)
- `server/src/com/mirth/connect/connectors/file/filesystems/WebDavConnection.java` — inline `// TODO` comment referencing SEC-V2-01 (Sardine migration deferred; Apache Slide `HttpURL` / `HttpsURL` runtime dependency).
- `server/src/com/mirth/connect/server/userutil/HTTPUtil.java` — inline `// TODO` comment referencing SEC-V2-01 companion (`HttpParser.parseHeaders()` rewrite deferred — no direct 4.x equivalent).
- `SECURITY.md` — appended a new "Known residual dependencies" section disclosing the residual `commons-httpclient-3.0.1.jar` on classpath.

Per RESEARCH.md, NO `build.xml` modification is required: the classpath is a glob `<fileset dir="${lib}" includes="**/*.jar" />` — the jar stays on disk and resolves transitively.

## Scope clarifications

- **Three constant-only callers migrated** (`HttpReceiver`, `MirthWebServer`, `ConnectServiceUtil`).
- **`WebDavConnection.java` and `HTTPUtil.java` intentionally NOT migrated** — both require behavior-level API rewrites and are deferred to SEC-V2-01 / SEC-V2-01 companion in the next milestone. Inline `// TODO` comments mark the deferral.
- **`commons-httpclient-3.0.1.jar` retained on classpath** at `server/lib/commons/commons-httpclient-3.0.1.jar` — required by `WebDavConnection.java` at runtime.
- **`server/build.xml` not modified** — the classpath is a glob (`<fileset dir="${lib}" includes="**/*.jar" />`); no individual jar entry exists to annotate. The two inline `// TODO` comments serve the discoverability intent.
- **Residual CVE exposure disclosed in `SECURITY.md`** under a new "Known residual dependencies" section.

## Test plan

- [x] Per-file gate grep: `grep -n "org.apache.commons.httpclient" <three target files>` returns ZERO matches.
- [x] Each target file contains exactly one `import org.apache.http.HttpStatus;` line.
- [x] `find server/lib -name 'commons-httpclient-3.0.1.jar' | wc -l` returns 1 (jar still on disk for WebDAV).
- [x] Transitive scan: no other jar in `server/lib` bundles `org/apache/commons/httpclient/` classes.
- [x] Deferred files (`WebDavConnection.java`, `HTTPUtil.java`) still import from `org.apache.commons.httpclient` (intentional — runtime resolution preserved) and now carry an explicit `// TODO` referencing SEC-V2-01.
- [ ] `ant -f server/build.xml compile` — **deferred to CI**: `ant`/`java` not available in the executor's local environment. Compile validation falls back to GitHub Actions on push.
- [ ] `ant -f server/build.xml test -Dtest=DigesterTest` and `-Dtest=DefaultUserControllerTest` — **deferred to CI** (same reason).
- [ ] Runtime WebDAV smoke test (manual; described in `.planning/phases/01-security-cluster/01-VALIDATION.md`).
- [ ] Second-set-of-eyes review.

## Residual risk disclosed

`commons-httpclient-3.0.1.jar` remains on classpath for the WebDAV `WebDavConnection.java` runtime dependency. CVE-2012-5783, CVE-2014-3577, and CVE-2015-5262 remain exposed in that code path until SEC-V2-01 lands. The migrated call sites (`HttpReceiver`, `MirthWebServer`, `ConnectServiceUtil`) are no longer exposed.


---

## Local test verification (2026-05-13)

Ant 1.10.14 + OpenJDK 17.0.18.

- `ant -f server/build.xml compile` — **BUILD SUCCESSFUL** (48s)
- `ant -f server/build.xml test-compile` — **BUILD SUCCESSFUL** (20s)
- `java org.junit.runner.JUnitCore` on the four test classes that exercise the migrated files:
  - `com.mirth.connect.server.MirthWebServerTest`
  - `com.mirth.connect.connectors.http.HttpReceiverTest`
  - `com.mirth.connect.connectors.http.HttpListenerRequestHeaderSizeTest`
  - `com.mirth.connect.connectors.http.HttpReceiverPropertiesTest`
  
  Result: **107 of 108 tests pass** in 7.7s.
  
  The single failure — `MirthWebServerTest.testContextPathNormalizationHandlesEmpty` (expected `/`, was empty string) — **is pre-existing on `bridgelink_development`**: rerunning the same test on trunk (`bridgelink_development` HEAD `afcfa7160`) produces the identical failure. Unrelated to the commons-httpclient import migration.

- Production-code grep gate: `grep -n "org.apache.commons.httpclient" server/src/com/mirth/connect/connectors/http/HttpReceiver.java server/src/com/mirth/connect/server/MirthWebServer.java server/src/com/mirth/connect/client/core/ConnectServiceUtil.java` returns **zero** matches. Each target file imports `org.apache.http.HttpStatus` exactly once.
- Deferred files (`WebDavConnection.java`, `HTTPUtil.java`) still resolve their `org.apache.commons.httpclient` imports — `commons-httpclient-3.0.1.jar` retained at `server/lib/commons/commons-httpclient-3.0.1.jar`. Server compiles cleanly with the deferred-file `// TODO` markers in place.
