### PR TITLE
Channel-aware logging: MDC context, centralized error logger, filterable Server Log

### DIFF
--- a/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
+++ b/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
@@ -30,15 +30,20 @@ public class ServerLogClient extends DashboardTabPlugin {
     private ServerLogPanel serverLogPanel;
     private LinkedList<ServerLogItem> serverLogs;
     private static final ServerLogItem unauthorizedLog = new ServerLogItem("You are not authorized to view the server log.");
-    private int currentServerLogSize;
+
+    // The fields below are touched from the Swing EDT (via resetServerLogSize) and from the
+    // dashboard's background polling thread (via prepareData/update). `volatile` ensures safe
+    // publication across threads. Compound updates of `serverLogs` itself still go through
+    // synchronized(this).
+    private volatile int currentServerLogSize;
     private boolean receivedNewLogs;
-    private Long lastLogId;
+    private volatile Long lastLogId;
     private String currentServerId;
 
     // The set of channel IDs currently highlighted on the dashboard. Empty means "no filter — show
     // everything from the unified server buffer". When this set changes we drop the local buffer
     // and reset lastLogId so the next fetch returns a fresh view of the new selection.
-    private Set<String> selectedChannelIds = Collections.emptySet();
+    private volatile Set<String> selectedChannelIds = Collections.emptySet();
 
     public ServerLogClient(String name) {
         super(name);

--- a/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
+++ b/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Mirth Corporation. All rights reserved.
- * 
+ *
  * http://www.mirthcorp.com
- * 
+ *
  * The software in this package is published under the terms of the MPL license a copy of which has
  * been included with this distribution in the LICENSE.txt file.
  */
@@ -10,8 +10,11 @@
 package com.mirth.connect.plugins.serverlog;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.JComponent;
 
@@ -32,6 +35,11 @@ public class ServerLogClient extends DashboardTabPlugin {
     private Long lastLogId;
     private String currentServerId;
 
+    // The set of channel IDs currently highlighted on the dashboard. Empty means "no filter — show
+    // everything from the unified server buffer". When this set changes we drop the local buffer
+    // and reset lastLogId so the next fetch returns a fresh view of the new selection.
+    private Set<String> selectedChannelIds = Collections.emptySet();
+
     public ServerLogClient(String name) {
         super(name);
         serverLogs = new LinkedList<ServerLogItem>();
@@ -45,14 +53,10 @@ public class ServerLogClient extends DashboardTabPlugin {
     }
 
     public void resetServerLogSize(int newServerLogSize) {
-
-        // the log size is always set to 100 on the server.
-        // on the client side, the max size is 99.  whenever that changes, only update the client side logs. the logs on the server will always be intact.
-        // Q. Does this log size affect all the channels? - Yes, it should.
-
-        // update (refresh) log only if the new logsize got smaller.
+        // The log size is always set to 100 on the server (per-buffer).
+        // On the client side, the max size is 99. When the user reduces it we only need to trim
+        // the local buffer; the server-side buffers are untouched.
         if (newServerLogSize < currentServerLogSize) {
-            // if log size got reduced...  remove that much extra LastRows.
             synchronized (this) {
                 while (newServerLogSize < serverLogs.size()) {
                     serverLogs.removeLast();
@@ -60,24 +64,40 @@ public class ServerLogClient extends DashboardTabPlugin {
             }
             serverLogPanel.updateTable(serverLogs);
         }
-
-        // reset currentServerLogSize.
         currentServerLogSize = newServerLogSize;
     }
 
     @Override
     public void prepareData() throws ClientException {
+        prepareData(null);
+    }
+
+    @Override
+    public void prepareData(List<DashboardStatus> statuses) throws ClientException {
         receivedNewLogs = false;
+
+        // Track which channels are selected on the dashboard. If the selection changed since the
+        // last poll, drop the local buffer and reset lastLogId so we re-fetch the relevant slice
+        // (otherwise we'd miss items whose IDs are below the previous lastLogId).
+        Set<String> nextSelection = extractChannelIds(statuses);
+        if (!nextSelection.equals(selectedChannelIds)) {
+            selectedChannelIds = nextSelection;
+            synchronized (this) {
+                serverLogs.clear();
+            }
+            lastLogId = null;
+        }
 
         if (!serverLogPanel.isPaused()) {
             List<ServerLogItem> serverLogReceived = new ArrayList<ServerLogItem>();
-            //get logs from server
             try {
-                serverLogReceived = PlatformUI.MIRTH_FRAME.mirthClient.getServlet(ServerLogServletInterface.class).getServerLogs(currentServerLogSize, lastLogId);
+                // null/empty channelIds → server returns from the unified buffer (legacy view).
+                // non-empty → server returns the requested channels + system rows merged.
+                Set<String> channelFilter = selectedChannelIds.isEmpty() ? null : selectedChannelIds;
+                serverLogReceived = PlatformUI.MIRTH_FRAME.mirthClient.getServlet(ServerLogServletInterface.class).getServerLogs(currentServerLogSize, lastLogId, channelFilter);
             } catch (ClientException e) {
                 if (e instanceof ForbiddenException) {
                     LinkedList<ServerLogItem> unauthorizedLogs = new LinkedList<ServerLogItem>();
-                    // Add the unauthorized log message if it's not already there.
                     if (serverLogs.isEmpty() || !serverLogs.getLast().equals(unauthorizedLog)) {
                         unauthorizedLogs.add(unauthorizedLog);
                     }
@@ -108,14 +128,26 @@ public class ServerLogClient extends DashboardTabPlugin {
         }
     }
 
-    @Override
-    public void prepareData(List<DashboardStatus> statuses) throws ClientException {
-        prepareData();
+    private static Set<String> extractChannelIds(List<DashboardStatus> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            return Collections.emptySet();
+        }
+        Set<String> ids = new HashSet<String>();
+        for (DashboardStatus status : statuses) {
+            if (status != null && status.getChannelId() != null) {
+                ids.add(status.getChannelId());
+            }
+        }
+        return ids.isEmpty() ? Collections.<String>emptySet() : ids;
     }
 
-    // used for setting actions to be called for updating when there is no status selected
     @Override
     public void update() {
+        update(null);
+    }
+
+    @Override
+    public void update(List<DashboardStatus> statuses) {
         boolean serverIdChanged = false;
         String serverId = null;
         for (DashboardTablePlugin plugin : LoadedExtensions.getInstance().getDashboardTablePlugins().values()) {
@@ -130,17 +162,8 @@ public class ServerLogClient extends DashboardTabPlugin {
         }
 
         if (!serverLogPanel.isPaused() && (receivedNewLogs || serverIdChanged)) {
-            // for mirth.log, channel being selected does not matter. display either way.
             serverLogPanel.updateTable(serverLogs);
         }
-    }
-
-    // used for setting actions to be called for updating when there is a status selected
-    public void update(List<DashboardStatus> statuses) {
-
-        // Mirth Server Log is irrelevant with Channel Status.  so just call the default update() method.
-        update();
-
     }
 
     @Override
@@ -148,17 +171,14 @@ public class ServerLogClient extends DashboardTabPlugin {
         return serverLogPanel;
     }
 
-    // used for starting processes in the plugin when the program is started
     @Override
     public void start() {}
 
-    // used for stopping processes in the plugin when the program is exited
     @Override
     public void stop() {
         reset();
     }
 
-    // Called when establishing a new session for the user.
     @Override
     public void reset() {
         clearLog();

--- a/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
+++ b/client/src/com/mirth/connect/plugins/serverlog/ServerLogClient.java
@@ -38,6 +38,11 @@ public class ServerLogClient extends DashboardTabPlugin {
     private volatile int currentServerLogSize;
     private boolean receivedNewLogs;
     private volatile Long lastLogId;
+
+    // Highest log id present when the user last clicked "Clear Log". Entries with an id <= this are
+    // suppressed on subsequent fetches, so re-selecting a channel — which resets lastLogId to re-pull
+    // the channel's slice — can't resurface cleared entries (IRT-1257). Null = nothing cleared.
+    private volatile Long clearedLogId;
     private String currentServerId;
 
     // The set of channel IDs currently highlighted on the dashboard. Empty means "no filter — show
@@ -53,6 +58,9 @@ public class ServerLogClient extends DashboardTabPlugin {
     }
 
     public void clearLog() {
+        // Remember the current watermark so cleared entries stay cleared even when a later channel
+        // re-selection resets lastLogId and re-fetches the full server-side buffer (IRT-1257).
+        clearedLogId = lastLogId;
         serverLogs.clear();
         serverLogPanel.updateTable(null);
     }
@@ -123,10 +131,17 @@ public class ServerLogClient extends DashboardTabPlugin {
 
                 synchronized (this) {
                     for (int i = serverLogReceived.size() - 1; i >= 0; i--) {
+                        ServerLogItem item = serverLogReceived.get(i);
+                        // Skip entries the user already cleared (IRT-1257). A channel re-selection
+                        // resets lastLogId and re-pulls the full buffer, which would otherwise
+                        // resurface them. Items with no id (e.g. the unauthorized notice) are kept.
+                        if (clearedLogId != null && item.getId() != null && item.getId() <= clearedLogId) {
+                            continue;
+                        }
                         while (currentServerLogSize <= serverLogs.size()) {
                             serverLogs.removeLast();
                         }
-                        serverLogs.addFirst(serverLogReceived.get(i));
+                        serverLogs.addFirst(item);
                     }
                 }
             }
@@ -186,6 +201,10 @@ public class ServerLogClient extends DashboardTabPlugin {
 
     @Override
     public void reset() {
+        // New session: server log ids restart when the server restarts, so forget the fetch
+        // watermark before clearing — otherwise a stale clearedLogId would filter out the fresh
+        // session's entries. clearLog() then sets clearedLogId from the (now null) lastLogId.
+        lastLogId = null;
         clearLog();
     }
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/Channel.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/Channel.java
@@ -1933,12 +1933,14 @@ public class Channel implements Runnable {
 
     @Override
     public void run() {
-        try {
-            do {
-                processSourceQueue(Constants.SOURCE_QUEUE_POLL_TIMEOUT_MILLIS);
-            } while (isActive() && !stopSourceQueue);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        try (LogContext.Scope channelScope = LogContext.channel(channelId, name)) {
+            try {
+                do {
+                    processSourceQueue(Constants.SOURCE_QUEUE_POLL_TIMEOUT_MILLIS);
+                } while (isActive() && !stopSourceQueue);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/DestinationConnector.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/DestinationConnector.java
@@ -485,6 +485,9 @@ public abstract class DestinationConnector extends Connector implements Runnable
      * @throws InterruptedException
      */
     public void process(DonkeyDao dao, ConnectorMessage message, Status previousStatus) throws InterruptedException {
+        try (LogContext.Scope channelScope = LogContext.channel(getChannelId(), channel.getName());
+             LogContext.Scope connectorScope = LogContext.connector(getDestinationName(), getMetaDataId());
+             LogContext.Scope messageScope = LogContext.message(message.getMessageId())) {
         ConnectorProperties connectorProperties = null;
 
         ThreadUtils.checkInterruptedStatus();
@@ -540,6 +543,7 @@ public abstract class DestinationConnector extends Connector implements Runnable
         } else {
             updateQueuedStatus(dao, message, previousStatus);
         }
+        }
     }
 
     public void updateQueuedStatus(DonkeyDao dao, ConnectorMessage message, Status previousStatus) throws InterruptedException {
@@ -579,7 +583,9 @@ public abstract class DestinationConnector extends Connector implements Runnable
                     dao.updateErrors(message);
                 }
             } catch (DonkeyException e) {
-                logger.error("Error executing response transformer for channel " + channel.getName() + " (" + channel.getChannelId() + ") on destination " + destinationName + ".", e);
+                // Logging is centralized in DefaultEventController.dispatchEvent — the response
+                // transformer dispatches an ErrorEvent before throwing, which the central handler
+                // logs to mirth.log with structured channel/connector/messageId MDC.
                 response.setStatus(Status.ERROR);
                 response.setError(e.getFormattedError());
                 message.setProcessingError(message.getProcessingError() != null ? message.getProcessingError() + System.getProperty("line.separator") + System.getProperty("line.separator") + e.getFormattedError() : e.getFormattedError());
@@ -613,6 +619,8 @@ public abstract class DestinationConnector extends Connector implements Runnable
 
     @Override
     public void run() {
+        try (LogContext.Scope channelScope = LogContext.channel(getChannelId(), channel.getName());
+             LogContext.Scope connectorScope = LogContext.connector(getDestinationName(), getMetaDataId())) {
         DonkeyDao dao = null;
         boolean commitSuccess = false;
         Serializer serializer = channel.getSerializer();
@@ -892,6 +900,7 @@ public abstract class DestinationConnector extends Connector implements Runnable
                 }
             }
         } while ((getCurrentState() == DeployedState.STARTED || getCurrentState() == DeployedState.STARTING) && !stopQueue.get());
+        }
     }
 
     private Response handleSend(ConnectorProperties connectorProperties, ConnectorMessage message) throws InterruptedException {
@@ -973,7 +982,7 @@ public abstract class DestinationConnector extends Connector implements Runnable
                 dao.updateErrors(message);
             }
         } catch (DonkeyException e) {
-            logger.error("Error executing response transformer for channel " + channel.getName() + " (" + channel.getChannelId() + ") on destination " + destinationName + ".", e);
+            // Logging is centralized in DefaultEventController.dispatchEvent — see note above.
             response.setStatus(Status.ERROR);
             response.setError(e.getFormattedError());
             message.setStatus(response.getStatus());

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/DestinationConnector.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/DestinationConnector.java
@@ -583,9 +583,14 @@ public abstract class DestinationConnector extends Connector implements Runnable
                     dao.updateErrors(message);
                 }
             } catch (DonkeyException e) {
-                // Logging is centralized in DefaultEventController.dispatchEvent — the response
-                // transformer dispatches an ErrorEvent before throwing, which the central handler
-                // logs to mirth.log with structured channel/connector/messageId MDC.
+                // When error-event logging is enabled, the response transformer's dispatched
+                // ErrorEvent is logged centrally in DefaultEventController.dispatchEvent (with
+                // structured channel/connector/messageId MDC), so logging here would duplicate it.
+                // When it's disabled (the legacy default), fall back to logging here so response
+                // transformer failures still reach mirth.log as they did before centralization.
+                if (!LogContext.isErrorEventLoggingEnabled()) {
+                    logger.error("Error executing response transformer for channel " + channel.getName() + " (" + channel.getChannelId() + ") on destination " + destinationName + ".", e);
+                }
                 response.setStatus(Status.ERROR);
                 response.setError(e.getFormattedError());
                 message.setProcessingError(message.getProcessingError() != null ? message.getProcessingError() + System.getProperty("line.separator") + System.getProperty("line.separator") + e.getFormattedError() : e.getFormattedError());
@@ -982,7 +987,11 @@ public abstract class DestinationConnector extends Connector implements Runnable
                 dao.updateErrors(message);
             }
         } catch (DonkeyException e) {
-            // Logging is centralized in DefaultEventController.dispatchEvent — see note above.
+            // Centralized when error-event logging is enabled; legacy fallback otherwise. See note
+            // in processPendingConnectorMessage above.
+            if (!LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error executing response transformer for channel " + channel.getName() + " (" + channel.getChannelId() + ") on destination " + destinationName + ".", e);
+            }
             response.setStatus(Status.ERROR);
             response.setError(e.getFormattedError());
             message.setStatus(response.getStatus());

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/LogContext.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/LogContext.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.donkey.server.channel;
+
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * Thin wrapper around Log4j2 ThreadContext (MDC) for channel-scoped log
+ * enrichment. Each helper method returns an AutoCloseable that restores
+ * the previous value of the affected keys on close, so scopes may be
+ * nested safely with try-with-resources and pooled threads cannot leak
+ * stale context between unrelated work units.
+ */
+public final class LogContext {
+
+    public static final String CHANNEL_ID = "channelId";
+    public static final String CHANNEL_NAME = "channelName";
+    public static final String META_DATA_ID = "metaDataId";
+    public static final String CONNECTOR = "connectorName";
+    public static final String MESSAGE_ID = "messageId";
+    public static final String SCRIPT_PHASE = "scriptPhase";
+    public static final String SCRIPT_LINE = "scriptLine";
+
+    private LogContext() {}
+
+    public static Scope channel(String channelId, String channelName) {
+        Scope scope = new Scope();
+        scope.put(CHANNEL_ID, channelId);
+        scope.put(CHANNEL_NAME, channelName);
+        return scope;
+    }
+
+    public static Scope connector(String connectorName, int metaDataId) {
+        Scope scope = new Scope();
+        scope.put(CONNECTOR, connectorName);
+        scope.put(META_DATA_ID, Integer.toString(metaDataId));
+        return scope;
+    }
+
+    public static Scope message(long messageId) {
+        Scope scope = new Scope();
+        scope.put(MESSAGE_ID, Long.toString(messageId));
+        return scope;
+    }
+
+    /**
+     * Scope for a JavaScript script execution failure: which phase (filter, transformer,
+     * response, etc.) and which line in the user's script triggered the error. lineNumber &lt; 0
+     * indicates the line is unknown.
+     */
+    public static Scope script(String phase, int lineNumber) {
+        Scope scope = new Scope();
+        scope.put(SCRIPT_PHASE, phase);
+        if (lineNumber >= 0) {
+            scope.put(SCRIPT_LINE, Integer.toString(lineNumber));
+        }
+        return scope;
+    }
+
+    public static void clear() {
+        ThreadContext.clearMap();
+    }
+
+    /**
+     * Records previous values for any keys it touches and restores them
+     * on close. Always use with try-with-resources.
+     */
+    public static final class Scope implements AutoCloseable {
+        private final java.util.Map<String, String> previous = new java.util.HashMap<>();
+        private final java.util.Set<String> addedKeys = new java.util.HashSet<>();
+
+        private void put(String key, String value) {
+            if (value == null) {
+                return;
+            }
+            String prior = ThreadContext.get(key);
+            if (!previous.containsKey(key) && !addedKeys.contains(key)) {
+                if (prior == null) {
+                    addedKeys.add(key);
+                } else {
+                    previous.put(key, prior);
+                }
+            }
+            ThreadContext.put(key, value);
+        }
+
+        @Override
+        public void close() {
+            for (String key : addedKeys) {
+                ThreadContext.remove(key);
+            }
+            for (java.util.Map.Entry<String, String> e : previous.entrySet()) {
+                ThreadContext.put(e.getKey(), e.getValue());
+            }
+        }
+    }
+}

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/LogContext.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/LogContext.java
@@ -30,7 +30,51 @@ public final class LogContext {
 
     private LogContext() {}
 
+    /**
+     * Whether channel-context (MDC) enrichment is active. When false, every factory method
+     * returns a shared no-op scope so no MDC keys are written and log lines render in the
+     * legacy format. Defaults to true so standalone/unit-test usage behaves as before; the
+     * server overrides this at startup from the {@code log.channelcontext.enabled}
+     * mirth.properties option (default false), making the production default opt-in.
+     */
+    private static volatile boolean enabled = true;
+
+    /**
+     * Whether dispatched ErrorEvents are mirrored to mirth.log. Defaults to false (opt-in): the
+     * legacy behavior keeps connector/transformer errors out of mirth.log (they remain visible in
+     * the in-app Server Log). The server sets this at startup from the {@code log.errorevent.enabled}
+     * mirth.properties option. It lives here, in the donkey module, so both DefaultEventController
+     * (server, the central error sink) and DestinationConnector (donkey, the legacy fallback) can
+     * consult it without a server-on-donkey dependency.
+     */
+    private static volatile boolean errorEventLoggingEnabled = false;
+
+    /**
+     * Shared no-op scope returned when enrichment is disabled. No keys are ever added to it,
+     * so {@link Scope#close()} is a no-op and the instance is safe to share across threads.
+     */
+    private static final Scope NOOP = new Scope();
+
+    public static void setEnabled(boolean value) {
+        enabled = value;
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static void setErrorEventLoggingEnabled(boolean value) {
+        errorEventLoggingEnabled = value;
+    }
+
+    public static boolean isErrorEventLoggingEnabled() {
+        return errorEventLoggingEnabled;
+    }
+
     public static Scope channel(String channelId, String channelName) {
+        if (!enabled) {
+            return NOOP;
+        }
         Scope scope = new Scope();
         scope.put(CHANNEL_ID, channelId);
         scope.put(CHANNEL_NAME, channelName);
@@ -38,6 +82,9 @@ public final class LogContext {
     }
 
     public static Scope connector(String connectorName, int metaDataId) {
+        if (!enabled) {
+            return NOOP;
+        }
         Scope scope = new Scope();
         scope.put(CONNECTOR, connectorName);
         scope.put(META_DATA_ID, Integer.toString(metaDataId));
@@ -45,6 +92,9 @@ public final class LogContext {
     }
 
     public static Scope message(long messageId) {
+        if (!enabled) {
+            return NOOP;
+        }
         Scope scope = new Scope();
         scope.put(MESSAGE_ID, Long.toString(messageId));
         return scope;
@@ -56,6 +106,9 @@ public final class LogContext {
      * indicates the line is unknown.
      */
     public static Scope script(String phase, int lineNumber) {
+        if (!enabled) {
+            return NOOP;
+        }
         Scope scope = new Scope();
         scope.put(SCRIPT_PHASE, phase);
         if (lineNumber >= 0) {

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/PollConnectorJob.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/PollConnectorJob.java
@@ -45,8 +45,11 @@ public class PollConnectorJob implements InterruptableJob {
                     String originalThreadName = thread.getName();
 
                     try {
-                        thread.setName(pollConnector.getConnectorProperties().getName() + " Polling Thread on " + pollConnector.getChannel().getName() + " (" + pollConnector.getChannelId() + ") < " + originalThreadName);
-                        pollConnector.poll();
+                        try (LogContext.Scope channelScope = LogContext.channel(pollConnector.getChannelId(), pollConnector.getChannel().getName());
+                             LogContext.Scope connectorScope = LogContext.connector(pollConnector.getConnectorProperties().getName(), 0)) {
+                            thread.setName(pollConnector.getConnectorProperties().getName() + " Polling Thread on " + pollConnector.getChannel().getName() + " (" + pollConnector.getChannelId() + ") < " + originalThreadName);
+                            pollConnector.poll();
+                        }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                     } finally {

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/RecoveryTask.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/RecoveryTask.java
@@ -40,11 +40,13 @@ public class RecoveryTask implements Callable<Void> {
     public Void call() throws Exception {
         String originalThreadName = Thread.currentThread().getName();
 
-        try {
+        try (LogContext.Scope channelScope = LogContext.channel(channel.getChannelId(), channel.getName())) {
             Thread.currentThread().setName("Recovery Task Thread on " + channel.getName() + " (" + channel.getChannelId() + ") < " + originalThreadName);
-            return doCall();
-        } finally {
-            Thread.currentThread().setName(originalThreadName);
+            try {
+                return doCall();
+            } finally {
+                Thread.currentThread().setName(originalThreadName);
+            }
         }
     }
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/SourceConnector.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/SourceConnector.java
@@ -185,13 +185,16 @@ public abstract class SourceConnector extends Connector {
      * @throws ChannelException
      */
     public DispatchResult dispatchRawMessage(RawMessage rawMessage, boolean force) throws ChannelException {
-        if (!force && getCurrentState() == DeployedState.STOPPED) {
-            ChannelException e = new ChannelException(true);
-            logger.warn("Source connector is currently stopped for channel " + channel.getName() + " (" + channel.getChannelId() + ").", e);
-            throw e;
-        }
+        try (LogContext.Scope channelScope = LogContext.channel(channel.getChannelId(), channel.getName());
+             LogContext.Scope connectorScope = LogContext.connector(sourceName, 0)) {
+            if (!force && getCurrentState() == DeployedState.STOPPED) {
+                ChannelException e = new ChannelException(true);
+                logger.warn("Source connector is currently stopped for channel " + channel.getName() + " (" + channel.getChannelId() + ").", e);
+                throw e;
+            }
 
-        return channel.dispatchRawMessage(rawMessage, false);
+            return channel.dispatchRawMessage(rawMessage, false);
+        }
     }
 
     public Boolean dispatchBatchMessage(BatchRawMessage batchRawMessage, ResponseHandler responseHandler) throws BatchMessageException {
@@ -316,7 +319,9 @@ public abstract class SourceConnector extends Connector {
             return;
         }
 
-        try {
+        try (LogContext.Scope channelScope = LogContext.channel(channel.getChannelId(), channel.getName());
+             LogContext.Scope connectorScope = LogContext.connector(sourceName, 0);
+             LogContext.Scope messageScope = LogContext.message(dispatchResult.getMessageId())) {
             boolean attemptedResponse = dispatchResult.isAttemptedResponse();
             String responseError = dispatchResult.getResponseError();
             Response selectedResponse = dispatchResult.getSelectedResponse();

--- a/donkey/src/test/java/com/mirth/connect/donkey/server/channel/LogContextTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/server/channel/LogContextTest.java
@@ -22,6 +22,9 @@ public class LogContextTest {
     @Before
     @After
     public void clear() {
+        // These tests assert the enriched (enabled) behavior. The server can flip this off at
+        // runtime via the log.channelcontext.enabled property, so set it explicitly here.
+        LogContext.setEnabled(true);
         ThreadContext.clearAll();
     }
 
@@ -142,5 +145,32 @@ public class LogContextTest {
             assertNull(ThreadContext.get(LogContext.META_DATA_ID));
         }
         assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+    }
+
+    /**
+     * When disabled (the production default, set by the server from log.channelcontext.enabled),
+     * every factory must be a no-op so no MDC keys are written and log lines stay in the legacy
+     * format. The returned no-op scope must also close cleanly.
+     */
+    @Test
+    public void disabled_writesNoContext() {
+        LogContext.setEnabled(false);
+        try {
+            try (LogContext.Scope c = LogContext.channel("abc", "Channel A");
+                 LogContext.Scope k = LogContext.connector("dest1", 7);
+                 LogContext.Scope m = LogContext.message(42L);
+                 LogContext.Scope s = LogContext.script("FILTER", 101)) {
+                assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+                assertNull(ThreadContext.get(LogContext.CHANNEL_NAME));
+                assertNull(ThreadContext.get(LogContext.CONNECTOR));
+                assertNull(ThreadContext.get(LogContext.META_DATA_ID));
+                assertNull(ThreadContext.get(LogContext.MESSAGE_ID));
+                assertNull(ThreadContext.get(LogContext.SCRIPT_PHASE));
+                assertNull(ThreadContext.get(LogContext.SCRIPT_LINE));
+            }
+            assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+        } finally {
+            LogContext.setEnabled(true);
+        }
     }
 }

--- a/donkey/src/test/java/com/mirth/connect/donkey/server/channel/LogContextTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/server/channel/LogContextTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.donkey.server.channel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class LogContextTest {
+
+    @Before
+    @After
+    public void clear() {
+        ThreadContext.clearAll();
+    }
+
+    @Test
+    public void channelScope_setsAndRestores() {
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+        try (LogContext.Scope s = LogContext.channel("abc", "Channel A")) {
+            assertEquals("abc", ThreadContext.get(LogContext.CHANNEL_ID));
+            assertEquals("Channel A", ThreadContext.get(LogContext.CHANNEL_NAME));
+        }
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+        assertNull(ThreadContext.get(LogContext.CHANNEL_NAME));
+    }
+
+    @Test
+    public void nestedScopes_innerRestoresPrior() {
+        try (LogContext.Scope outer = LogContext.channel("outer-id", "Outer")) {
+            assertEquals("outer-id", ThreadContext.get(LogContext.CHANNEL_ID));
+            try (LogContext.Scope inner = LogContext.channel("inner-id", "Inner")) {
+                assertEquals("inner-id", ThreadContext.get(LogContext.CHANNEL_ID));
+                assertEquals("Inner", ThreadContext.get(LogContext.CHANNEL_NAME));
+            }
+            assertEquals("outer-id", ThreadContext.get(LogContext.CHANNEL_ID));
+            assertEquals("Outer", ThreadContext.get(LogContext.CHANNEL_NAME));
+        }
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+    }
+
+    @Test
+    public void connectorScope_addsMetaDataId() {
+        try (LogContext.Scope c = LogContext.channel("c1", "C1");
+             LogContext.Scope k = LogContext.connector("dest1", 7)) {
+            assertEquals("c1", ThreadContext.get(LogContext.CHANNEL_ID));
+            assertEquals("dest1", ThreadContext.get(LogContext.CONNECTOR));
+            assertEquals("7", ThreadContext.get(LogContext.META_DATA_ID));
+        }
+        assertNull(ThreadContext.get(LogContext.CONNECTOR));
+        assertNull(ThreadContext.get(LogContext.META_DATA_ID));
+    }
+
+    @Test
+    public void messageScope_setsMessageId() {
+        try (LogContext.Scope m = LogContext.message(42L)) {
+            assertEquals("42", ThreadContext.get(LogContext.MESSAGE_ID));
+        }
+        assertNull(ThreadContext.get(LogContext.MESSAGE_ID));
+    }
+
+    @Test
+    public void nullValue_doesNotPollute() {
+        try (LogContext.Scope s = LogContext.channel("c", null)) {
+            assertEquals("c", ThreadContext.get(LogContext.CHANNEL_ID));
+            assertNull(ThreadContext.get(LogContext.CHANNEL_NAME));
+        }
+    }
+
+    /**
+     * Pre-existing MDC value (set outside any Scope, e.g. by a non-LogContext caller)
+     * must be restored when an inner Scope that overwrites it closes.
+     */
+    @Test
+    public void overwritingExistingKey_restoresPriorValue() {
+        ThreadContext.put(LogContext.CHANNEL_ID, "preset");
+        try {
+            try (LogContext.Scope s = LogContext.channel("inner", "InnerName")) {
+                assertEquals("inner", ThreadContext.get(LogContext.CHANNEL_ID));
+            }
+            assertEquals("preset", ThreadContext.get(LogContext.CHANNEL_ID));
+        } finally {
+            ThreadContext.remove(LogContext.CHANNEL_ID);
+        }
+    }
+
+    /** Closing a Scope twice must be safe — the second close is a no-op. */
+    @Test
+    public void close_isIdempotent() {
+        LogContext.Scope s = LogContext.channel("c", "C");
+        assertEquals("c", ThreadContext.get(LogContext.CHANNEL_ID));
+        s.close();
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+        // Second close must not re-remove or throw
+        s.close();
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+    }
+
+    /** clear() empties the MDC map. */
+    @Test
+    public void clear_emptiesAllKeys() {
+        ThreadContext.put(LogContext.CHANNEL_ID, "c");
+        ThreadContext.put(LogContext.MESSAGE_ID, "1");
+        LogContext.clear();
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+        assertNull(ThreadContext.get(LogContext.MESSAGE_ID));
+    }
+
+    /** ChannelTask-style scope: connector with a null name but a metaDataId. */
+    @Test
+    public void connectorScope_withNullName_setsOnlyMetaDataId() {
+        try (LogContext.Scope k = LogContext.connector(null, 3)) {
+            assertNull(ThreadContext.get(LogContext.CONNECTOR));
+            assertEquals("3", ThreadContext.get(LogContext.META_DATA_ID));
+        }
+        assertNull(ThreadContext.get(LogContext.META_DATA_ID));
+    }
+
+    /** Two stacked scopes setting disjoint keys: outer keys must survive inner close. */
+    @Test
+    public void disjointStackedScopes_restoreIndependently() {
+        try (LogContext.Scope outer = LogContext.channel("c-outer", "Outer")) {
+            try (LogContext.Scope inner = LogContext.connector("destA", 5)) {
+                assertEquals("c-outer", ThreadContext.get(LogContext.CHANNEL_ID));
+                assertEquals("destA", ThreadContext.get(LogContext.CONNECTOR));
+                assertEquals("5", ThreadContext.get(LogContext.META_DATA_ID));
+            }
+            // Inner closed: connector keys gone, channel keys still set.
+            assertEquals("c-outer", ThreadContext.get(LogContext.CHANNEL_ID));
+            assertNull(ThreadContext.get(LogContext.CONNECTOR));
+            assertNull(ThreadContext.get(LogContext.META_DATA_ID));
+        }
+        assertNull(ThreadContext.get(LogContext.CHANNEL_ID));
+    }
+}

--- a/server/conf/log4j2.properties
+++ b/server/conf/log4j2.properties
@@ -5,7 +5,7 @@ rootLogger = ERROR,stdout,fout
 appender.console.type = Console
 appender.console.name = stdout
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c: %m%n
+appender.console.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName=%X{channelName}}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName=%X{connectorName}}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
 appender.console.layout.charset = UTF-8
 
 # file appender
@@ -20,7 +20,7 @@ appender.rolling.policies.size.size = 500KB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 20
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c: %m%n
+appender.rolling.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName=%X{channelName}}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName=%X{connectorName}}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
 
 # splash screen
 logger.mirth.name = com.mirth.connect.server.Mirth

--- a/server/conf/log4j2.properties
+++ b/server/conf/log4j2.properties
@@ -5,7 +5,7 @@ rootLogger = ERROR,stdout,fout
 appender.console.type = Console
 appender.console.name = stdout
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName=%X{channelName}}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName=%X{connectorName}}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
+appender.console.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName="%X{channelName}"}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName="%X{connectorName}"}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
 appender.console.layout.charset = UTF-8
 
 # file appender
@@ -20,7 +20,7 @@ appender.rolling.policies.size.size = 500KB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 20
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName=%X{channelName}}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName=%X{connectorName}}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
+appender.rolling.layout.pattern = %-5p %d{yyyy-MM-dd HH:mm:ss.SSS} [%t]%notEmpty{ channelId=%X{channelId}}%notEmpty{ channelName="%X{channelName}"}%notEmpty{ metaDataId=%X{metaDataId}}%notEmpty{ connectorName="%X{connectorName}"}%notEmpty{ messageId=%X{messageId}}%notEmpty{ scriptPhase=%X{scriptPhase}}%notEmpty{ scriptLine=%X{scriptLine}} %c: %m%n
 
 # splash screen
 logger.mirth.name = com.mirth.connect.server.Mirth

--- a/server/conf/mirth.properties
+++ b/server/conf/mirth.properties
@@ -69,6 +69,19 @@ server.includecustomlib = false
 # Security: prevent startup as root/Administrator (set to true only if intentional, not recommended)
 server.allowRoot = false
 
+# When true, channel/connector/message context (channelId, channelName, metaDataId,
+# connectorName, messageId, scriptPhase, scriptLine) is appended to mirth.log lines emitted
+# during channel work, and the Dashboard Server Log can be filtered by selected channel(s).
+# Leave false if you have log-parsing/aggregation rules that expect the legacy line format;
+# with it off, log lines are unchanged and the Server Log shows the unified view.
+log.channelcontext.enabled = false
+
+# When true, every connector/transformer error (HTTP/TCP/JMS/JDBC/File/SMTP/WS sender, filter,
+# transformer, response transformer, etc.) is written to mirth.log in addition to the in-app
+# Server Log. Leave false to keep connector errors out of mirth.log (legacy behavior); they
+# remain visible in the in-app Server Log either way.
+log.errorevent.enabled = false
+
 # administrator
 administrator.maxheapsize = 512m
 

--- a/server/src/com/mirth/connect/connectors/dimse/DICOMDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/dimse/DICOMDispatcher.java
@@ -35,6 +35,7 @@ import com.mirth.connect.donkey.model.message.Status;
 import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.util.DonkeyElement;
 import com.mirth.connect.server.controllers.ConfigurationController;
@@ -281,6 +282,9 @@ public class DICOMDispatcher extends DestinationConnector {
         } catch (Exception e) {
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse(e.getMessage(), e);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), e.getMessage(), null);
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error sending DICOM message", e);
+            }
             eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), e.getMessage(), null));
         } finally {
             dcmSnd.stop();

--- a/server/src/com/mirth/connect/connectors/doc/DocumentDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/doc/DocumentDispatcher.java
@@ -48,6 +48,7 @@ import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.controllers.MessageController;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.util.Base64Util;
 import com.mirth.connect.donkey.util.DonkeyElement;
@@ -139,6 +140,9 @@ public class DocumentDispatcher extends DestinationConnector {
 
             responseStatus = Status.SENT;
         } catch (Exception e) {
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error writing document", e);
+            }
             eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Error writing document", e));
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Error writing document", e);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), "Error writing document", e);

--- a/server/src/com/mirth/connect/connectors/file/FileDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/file/FileDispatcher.java
@@ -28,6 +28,7 @@ import com.mirth.connect.donkey.model.message.Status;
 import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.util.ThreadUtils;
 import com.mirth.connect.server.controllers.ConfigurationController;
@@ -181,6 +182,9 @@ public class FileDispatcher extends DestinationConnector {
             responseStatusMessage = "File successfully written: " + fileDispatcherProperties.toURIString();
             responseStatus = Status.SENT;
         } catch (Exception e) {
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error writing file", e);
+            }
             eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Error writing file", e));
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Error writing file", e);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), "Error writing file", e);

--- a/server/src/com/mirth/connect/connectors/http/HttpDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/http/HttpDispatcher.java
@@ -107,6 +107,7 @@ import com.mirth.connect.donkey.model.message.Status;
 import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.util.Base64Util;
 import com.mirth.connect.server.controllers.ConfigurationController;
@@ -419,11 +420,17 @@ public class HttpDispatcher extends DestinationConnector {
             if (statusCode < HttpStatus.SC_BAD_REQUEST) {
                 responseStatus = Status.SENT;
             } else {
+                if (LogContext.isErrorEventLoggingEnabled()) {
+                    logger.error("Received error response from HTTP server.");
+                }
                 eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Received error response from HTTP server.", null));
                 responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Received error response from HTTP server.", null);
                 responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), responseData, null);
             }
         } catch (Throwable t) {
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error connecting to HTTP server.", t);
+            }
             eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Error connecting to HTTP server.", t));
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Error connecting to HTTP server", t);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), "Error connecting to HTTP server", t);

--- a/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcher.java
@@ -34,6 +34,7 @@ import com.mirth.connect.donkey.model.message.attachment.AttachmentHandlerProvid
 import com.mirth.connect.donkey.server.ConnectorTaskException;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.server.controllers.ConfigurationController;
 import com.mirth.connect.server.controllers.ControllerFactory;
@@ -277,6 +278,9 @@ public class SmtpDispatcher extends DestinationConnector {
             responseStatus = Status.SENT;
             responseStatusMessage = "Email sent successfully.";
         } catch (Exception e) {
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error sending email message", e);
+            }
             eventController.dispatchEvent(new ErrorEvent(getChannelId(), getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Error sending email message", e));
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Error sending email message", e);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), "Error sending email message", e);

--- a/server/src/com/mirth/connect/connectors/vm/VmDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/vm/VmDispatcher.java
@@ -30,6 +30,7 @@ import com.mirth.connect.donkey.server.Constants;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.channel.DispatchResult;
 import com.mirth.connect.donkey.server.event.ConnectionStatusEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.server.controllers.ConfigurationController;
 import com.mirth.connect.server.controllers.ControllerFactory;
@@ -168,6 +169,9 @@ public class VmDispatcher extends DestinationConnector {
             responseStatus = Status.SENT;
             responseStatusMessage = "Message routed successfully to channel id: " + targetChannelId;
         } catch (Throwable e) {
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error routing message to channel id: " + targetChannelId, e);
+            }
             eventController.dispatchEvent(new ErrorEvent(currentChannelId, getMetaDataId(), message.getMessageId(), ErrorEventType.DESTINATION_CONNECTOR, getDestinationName(), connectorProperties.getName(), "Error routing message to channel id: " + targetChannelId, e));
             responseStatusMessage = ErrorMessageBuilder.buildErrorResponse("Error routing message to channel id: " + targetChannelId, e);
             responseError = ErrorMessageBuilder.buildErrorMessage(connectorProperties.getName(), "Error routing message to channel id: " + targetChannelId, e);

--- a/server/src/com/mirth/connect/plugins/serverlog/ArrayAppender.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ArrayAppender.java
@@ -44,7 +44,9 @@ public class ArrayAppender extends AbstractAppender {
         String category = logEvent.getLoggerName();
         String message = logEvent.getMessage().getFormattedMessage();
 
-        String channelPrefix = buildChannelPrefix(logEvent.getContextData());
+        ReadOnlyStringMap ctx = logEvent.getContextData();
+        String channelId = (ctx != null) ? ctx.getValue(LogContext.CHANNEL_ID) : null;
+        String channelPrefix = buildChannelPrefix(ctx);
         if (!channelPrefix.isEmpty()) {
             message = channelPrefix + " " + message;
         }
@@ -68,7 +70,7 @@ public class ArrayAppender extends AbstractAppender {
             throwableInformation = logText.toString();
         }
 
-        serverLogProvider.newServerLogReceived(level, date, threadName, category, lineNumber, message, throwableInformation);
+        serverLogProvider.newServerLogReceived(level, date, threadName, category, lineNumber, message, throwableInformation, channelId);
     }
 
     private static String buildChannelPrefix(ReadOnlyStringMap ctx) {

--- a/server/src/com/mirth/connect/plugins/serverlog/ArrayAppender.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ArrayAppender.java
@@ -17,8 +17,10 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.Strings;
 
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.server.logging.MirthLog4jFilter;
 
 public class ArrayAppender extends AbstractAppender {
@@ -42,6 +44,11 @@ public class ArrayAppender extends AbstractAppender {
         String category = logEvent.getLoggerName();
         String message = logEvent.getMessage().getFormattedMessage();
 
+        String channelPrefix = buildChannelPrefix(logEvent.getContextData());
+        if (!channelPrefix.isEmpty()) {
+            message = channelPrefix + " " + message;
+        }
+
         String lineNumber = "?";
         StackTraceElement source = logEvent.getSource();
         if (source != null) {
@@ -62,5 +69,30 @@ public class ArrayAppender extends AbstractAppender {
         }
 
         serverLogProvider.newServerLogReceived(level, date, threadName, category, lineNumber, message, throwableInformation);
+    }
+
+    private static String buildChannelPrefix(ReadOnlyStringMap ctx) {
+        if (ctx == null || ctx.isEmpty()) {
+            return "";
+        }
+        String name = ctx.getValue(LogContext.CHANNEL_NAME);
+        String id = ctx.getValue(LogContext.CHANNEL_ID);
+        String connector = ctx.getValue(LogContext.CONNECTOR);
+        String msgId = ctx.getValue(LogContext.MESSAGE_ID);
+
+        if (name == null && id == null) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder("[channel=");
+        sb.append(name != null ? name : id);
+        if (connector != null && !connector.isEmpty()) {
+            sb.append(", connector=").append(connector);
+        }
+        if (msgId != null && !msgId.isEmpty()) {
+            sb.append(", msgId=").append(msgId);
+        }
+        sb.append(']');
+        return sb.toString();
     }
 }

--- a/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
@@ -66,6 +66,12 @@ public class DefaultServerLogController extends ServerLogController {
 
     @Override
     public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId, Set<String> channelIds) {
+        // Defensive: a missing or negative fetchSize from the REST binding would otherwise blow
+        // up the ArrayList constructor below with NegativeArraySizeException.
+        if (fetchSize < 0) {
+            fetchSize = 0;
+        }
+
         // Snapshot the relevant buffers under the lock, then build the response outside it so we
         // don't hold the lock across the (small) sort/filter cost.
         List<ServerLogItem> snapshot;

--- a/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) Mirth Corporation. All rights reserved.
- * 
+ *
  * http://www.mirthcorp.com
- * 
+ *
  * The software in this package is published under the terms of the MPL license a copy of which has
  * been included with this distribution in the LICENSE.txt file.
  */
@@ -10,52 +10,118 @@
 package com.mirth.connect.plugins.serverlog;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.commons.lang3.SerializationException;
-import org.apache.commons.lang3.SerializationUtils;
+import java.util.Map;
+import java.util.Set;
 
 public class DefaultServerLogController extends ServerLogController {
 
-    private static int LOG_SIZE = 100; // maximum number of log entries. not the number of lines.
+    // Maximum entries per buffer (the unified buffer, the per-channel buffers, and the system buffer
+    // are each capped at this value). Not the number of lines.
+    private static final int LOG_SIZE = 100;
 
-    private static LinkedList<ServerLogItem> serverLogs = new LinkedList<ServerLogItem>();
+    // Unified buffer of every entry, used when no channel filter is requested.
+    private final LinkedList<ServerLogItem> allLogs = new LinkedList<ServerLogItem>();
+
+    // Per-channel buffers so a noisy channel cannot evict a quiet channel's history.
+    private final Map<String, LinkedList<ServerLogItem>> channelLogs = new HashMap<String, LinkedList<ServerLogItem>>();
+
+    // System buffer: entries with no channel context (startup, shutdown, FATAL, etc.). Always
+    // merged into channel-filtered results so critical events remain visible regardless of selection.
+    private final LinkedList<ServerLogItem> systemLogs = new LinkedList<ServerLogItem>();
+
+    private final Object lock = new Object();
 
     protected DefaultServerLogController() {}
 
     @Override
-    public synchronized void addLogItem(ServerLogItem logItem) {
-        if (serverLogs.size() == LOG_SIZE) {
-            serverLogs.removeLast();
+    public void addLogItem(ServerLogItem logItem) {
+        synchronized (lock) {
+            addBounded(allLogs, logItem);
+            String channelId = logItem.getChannelId();
+            if (channelId != null) {
+                LinkedList<ServerLogItem> bucket = channelLogs.get(channelId);
+                if (bucket == null) {
+                    bucket = new LinkedList<ServerLogItem>();
+                    channelLogs.put(channelId, bucket);
+                }
+                addBounded(bucket, logItem);
+            } else {
+                addBounded(systemLogs, logItem);
+            }
         }
+    }
 
-        serverLogs.addFirst(logItem);
+    private static void addBounded(LinkedList<ServerLogItem> buffer, ServerLogItem item) {
+        if (buffer.size() == LOG_SIZE) {
+            buffer.removeLast();
+        }
+        buffer.addFirst(item);
     }
 
     @Override
-    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId) {
-        // work with deep copied clone of the static server logs object in
-        // order to avoid multiple threads ConcurrentModificationException.
-        LinkedList<ServerLogItem> serverLogsCloned = new LinkedList<ServerLogItem>();
+    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId, Set<String> channelIds) {
+        // Snapshot the relevant buffers under the lock, then build the response outside it so we
+        // don't hold the lock across the (small) sort/filter cost.
+        List<ServerLogItem> snapshot;
 
-        try {
-            serverLogsCloned = (LinkedList<ServerLogItem>) SerializationUtils.clone(serverLogs);
-        } catch (SerializationException e) {
-            // ignore
-        }
-
-        List<ServerLogItem> newServerLogEntries = new ArrayList<ServerLogItem>();
-
-        for (ServerLogItem logItem : serverLogsCloned) {
-            if (lastLogId == null || lastLogId < logItem.getId()) {
-                newServerLogEntries.add(logItem);
-                if (newServerLogEntries.size() >= fetchSize) {
-                    break;
+        synchronized (lock) {
+            if (channelIds == null || channelIds.isEmpty()) {
+                // No channel filter: return from the unified buffer (unchanged legacy behavior).
+                snapshot = new ArrayList<ServerLogItem>(allLogs);
+            } else {
+                // Merge the requested per-channel buffers with the system buffer. Deduplicate by
+                // id in case the same item somehow ended up in both (defensive — shouldn't happen
+                // with the current addLogItem branching).
+                Set<Long> seenIds = new HashSet<Long>();
+                snapshot = new ArrayList<ServerLogItem>();
+                for (String channelId : channelIds) {
+                    LinkedList<ServerLogItem> bucket = channelLogs.get(channelId);
+                    if (bucket == null) {
+                        continue;
+                    }
+                    for (ServerLogItem item : bucket) {
+                        if (item.getId() != null && seenIds.add(item.getId())) {
+                            snapshot.add(item);
+                        }
+                    }
+                }
+                for (ServerLogItem item : systemLogs) {
+                    if (item.getId() != null && seenIds.add(item.getId())) {
+                        snapshot.add(item);
+                    }
                 }
             }
         }
 
-        return newServerLogEntries;
+        // Sort newest first by id (id is monotonically increasing per server).
+        Collections.sort(snapshot, new Comparator<ServerLogItem>() {
+            @Override
+            public int compare(ServerLogItem a, ServerLogItem b) {
+                Long ida = a.getId();
+                Long idb = b.getId();
+                if (ida == null && idb == null) return 0;
+                if (ida == null) return 1;
+                if (idb == null) return -1;
+                return Long.compare(idb, ida);
+            }
+        });
+
+        List<ServerLogItem> result = new ArrayList<ServerLogItem>(Math.min(fetchSize, snapshot.size()));
+        for (ServerLogItem item : snapshot) {
+            if (lastLogId != null && item.getId() != null && item.getId() <= lastLogId) {
+                continue;
+            }
+            result.add(item);
+            if (result.size() >= fetchSize) {
+                break;
+            }
+        }
+        return result;
     }
 }

--- a/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/DefaultServerLogController.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.mirth.connect.donkey.server.channel.LogContext;
+
 public class DefaultServerLogController extends ServerLogController {
 
     // Maximum entries per buffer (the unified buffer, the per-channel buffers, and the system buffer
@@ -77,8 +79,11 @@ public class DefaultServerLogController extends ServerLogController {
         List<ServerLogItem> snapshot;
 
         synchronized (lock) {
-            if (channelIds == null || channelIds.isEmpty()) {
-                // No channel filter: return from the unified buffer (unchanged legacy behavior).
+            if (channelIds == null || channelIds.isEmpty() || !LogContext.isEnabled()) {
+                // No channel filter, or channel-context logging is disabled (log.channelcontext.enabled
+                // = false): with context off, no entry carries a channelId and the per-channel buffers
+                // are empty, so channel filtering is meaningless. Return the unified buffer — the
+                // dependency is explicit and the in-app Server Log can never show an empty pane.
                 snapshot = new ArrayList<ServerLogItem>(allLogs);
             } else {
                 // Merge the requested per-channel buffers with the system buffer. Deduplicate by

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogController.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogController.java
@@ -10,6 +10,7 @@
 package com.mirth.connect.plugins.serverlog;
 
 import java.util.List;
+import java.util.Set;
 
 import com.mirth.connect.server.ExtensionLoader;
 
@@ -33,5 +34,18 @@ public abstract class ServerLogController {
 
     public abstract void addLogItem(ServerLogItem logItem);
 
-    public abstract List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId);
+    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId) {
+        return getServerLogs(fetchSize, lastLogId, null);
+    }
+
+    /**
+     * Returns recent server log entries.
+     *
+     * @param fetchSize  max number of entries to return
+     * @param lastLogId  if non-null, only entries with an id strictly greater than this are returned
+     * @param channelIds if null or empty, returns entries from the unified buffer (all channels).
+     *                   Otherwise returns entries from the requested per-channel buffers merged
+     *                   with the system buffer (entries with no channel context).
+     */
+    public abstract List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId, Set<String> channelIds);
 }

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogItem.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogItem.java
@@ -28,14 +28,19 @@ public class ServerLogItem implements Serializable {
     private String lineNumber;
     private String message;
     private String throwableInformation;
+    private String channelId;
 
     public ServerLogItem() {}
 
     public ServerLogItem(String message) {
-        this(null, null, null, null, null, null, null, message, null);
+        this(null, null, null, null, null, null, null, message, null, null);
     }
 
     public ServerLogItem(String serverId, Long id, String level, Date date, String threadName, String category, String lineNumber, String message, String throwableInformation) {
+        this(serverId, id, level, date, threadName, category, lineNumber, message, throwableInformation, null);
+    }
+
+    public ServerLogItem(String serverId, Long id, String level, Date date, String threadName, String category, String lineNumber, String message, String throwableInformation, String channelId) {
         this.serverId = serverId;
         this.id = id;
         this.level = level;
@@ -45,6 +50,7 @@ public class ServerLogItem implements Serializable {
         this.lineNumber = lineNumber;
         this.message = message;
         this.throwableInformation = throwableInformation;
+        this.channelId = channelId;
     }
 
     public String getServerId() {
@@ -117,6 +123,14 @@ public class ServerLogItem implements Serializable {
 
     public void setThrowableInformation(String throwableInformation) {
         this.throwableInformation = throwableInformation;
+    }
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public void setChannelId(String channelId) {
+        this.channelId = channelId;
     }
 
     @Override

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogProvider.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogProvider.java
@@ -55,16 +55,20 @@ public class ServerLogProvider implements ServicePlugin {
         initialize();
     }
 
-    public synchronized void newServerLogReceived(String level, Date date, String threadName, String category, String lineNumber, String message, String throwableInformation) {
+    public synchronized void newServerLogReceived(String level, Date date, String threadName, String category, String lineNumber, String message, String throwableInformation, String channelId) {
         if (logController != null) {
-            logController.addLogItem(new ServerLogItem(serverId, logId, level, date, threadName, category, lineNumber, message, throwableInformation));
+            logController.addLogItem(new ServerLogItem(serverId, logId, level, date, threadName, category, lineNumber, message, throwableInformation, channelId));
             logId++;
         }
     }
 
     public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId) {
+        return getServerLogs(fetchSize, lastLogId, null);
+    }
+
+    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId, java.util.Set<String> channelIds) {
         if (logController != null) {
-            return logController.getServerLogs(fetchSize, lastLogId);
+            return logController.getServerLogs(fetchSize, lastLogId, channelIds);
         } else {
             return new ArrayList<ServerLogItem>();
         }

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogServlet.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogServlet.java
@@ -10,6 +10,7 @@
 package com.mirth.connect.plugins.serverlog;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
@@ -27,7 +28,7 @@ public class ServerLogServlet extends MirthServlet implements ServerLogServletIn
     }
 
     @Override
-    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId) {
-        return provider.getServerLogs(fetchSize, lastLogId);
+    public List<ServerLogItem> getServerLogs(int fetchSize, Long lastLogId, Set<String> channelIds) {
+        return provider.getServerLogs(fetchSize, lastLogId, channelIds);
     }
 }

--- a/server/src/com/mirth/connect/plugins/serverlog/ServerLogServletInterface.java
+++ b/server/src/com/mirth/connect/plugins/serverlog/ServerLogServletInterface.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -51,6 +52,7 @@ public interface ServerLogServletInterface extends BaseServletInterface {
     @MirthOperation(name = "getMirthServerLogs", display = "View Server Log", permission = PERMISSION_VIEW, type = ExecuteType.ASYNC, auditable = false)
     public List<ServerLogItem> getServerLogs(// @formatter:off
             @Param("fetchSize") @Parameter(description = "Specifies the maximum number of log items to return.", required = true, schema = @Schema(defaultValue = "100")) @QueryParam("fetchSize") int fetchSize,
-            @Param("lastLogId") @Parameter(description = "The last log ID the client retrieved. Only log items with a greater ID will be returned.") @QueryParam("lastLogId") Long lastLogId) throws ClientException;
+            @Param("lastLogId") @Parameter(description = "The last log ID the client retrieved. Only log items with a greater ID will be returned.") @QueryParam("lastLogId") Long lastLogId,
+            @Param("channelId") @Parameter(description = "If supplied, only entries for the listed channels (plus channel-less system entries) are returned. Repeat the parameter for multiple channels. Omit to fetch all entries.") @QueryParam("channelId") Set<String> channelIds) throws ClientException;
     // @formatter:on
 }

--- a/server/src/com/mirth/connect/server/channel/ChannelTask.java
+++ b/server/src/com/mirth/connect/server/channel/ChannelTask.java
@@ -13,6 +13,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
+import com.mirth.connect.donkey.server.channel.LogContext;
+
 public abstract class ChannelTask implements Callable<Void> {
 
     protected String channelId;
@@ -51,7 +53,8 @@ public abstract class ChannelTask implements Callable<Void> {
     @Override
     public final Void call() throws Exception {
         String originalThreadName = Thread.currentThread().getName();
-        try {
+        try (LogContext.Scope channelScope = LogContext.channel(channelId, null);
+             LogContext.Scope connectorScope = metaDataId != null ? LogContext.connector(null, metaDataId) : null) {
             if (metaDataId != null) {
                 Thread.currentThread().setName("Channel " + getClass().getSimpleName() + " Thread on (" + channelId + ") connector (" + metaDataId + ") < " + originalThreadName);
             } else {
@@ -62,6 +65,7 @@ public abstract class ChannelTask implements Callable<Void> {
                 handler = new ChannelTaskHandler();
             }
 
+            // Catch is inside the resource scopes so handler.taskErrored() logs with channel+connector MDC.
             try {
                 handler.taskStarted(channelId, metaDataId);
                 execute();

--- a/server/src/com/mirth/connect/server/channel/ChannelTask.java
+++ b/server/src/com/mirth/connect/server/channel/ChannelTask.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
 import com.mirth.connect.donkey.server.channel.LogContext;
+import com.mirth.connect.model.Channel;
+import com.mirth.connect.server.controllers.ChannelController;
 
 public abstract class ChannelTask implements Callable<Void> {
 
@@ -53,7 +55,21 @@ public abstract class ChannelTask implements Callable<Void> {
     @Override
     public final Void call() throws Exception {
         String originalThreadName = Thread.currentThread().getName();
-        try (LogContext.Scope channelScope = LogContext.channel(channelId, null);
+
+        // Best-effort channel name so admin-task error logging (deploy/undeploy/start/stop, logged
+        // via LoggingTaskHandler) carries channelName instead of the channel GUID. Failures here
+        // must never break task execution, so swallow any lookup error.
+        String channelName = null;
+        try {
+            Channel channelModel = ChannelController.getInstance().getChannelById(channelId);
+            if (channelModel != null) {
+                channelName = channelModel.getName();
+            }
+        } catch (Exception ignore) {
+            // ignore — the name is only used for log context
+        }
+
+        try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName);
              LogContext.Scope connectorScope = metaDataId != null ? LogContext.connector(null, metaDataId) : null) {
             if (metaDataId != null) {
                 Thread.currentThread().setName("Channel " + getClass().getSimpleName() + " Thread on (" + channelId + ") connector (" + metaDataId + ") < " + originalThreadName);

--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -105,6 +105,7 @@ import com.mirth.commons.encryption.Output;
 import com.mirth.connect.client.core.ControllerException;
 import com.mirth.connect.client.core.PropertiesConfigurationUtil;
 import com.mirth.connect.donkey.model.DatabaseConstants;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.data.DonkeyStatisticsUpdater;
 import com.mirth.connect.donkey.util.DonkeyElement;
 import com.mirth.connect.model.Channel;
@@ -196,6 +197,8 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
     private static final String HTTPS_SERVER_PROTOCOLS = "https.server.protocols";
     private static final String HTTPS_CIPHER_SUITES = "https.ciphersuites";
     private static final String STARTUP_DEPLOY = "server.startupdeploy";
+    private static final String LOG_CHANNEL_CONTEXT_ENABLED = "log.channelcontext.enabled";
+    private static final String LOG_ERROR_EVENT_ENABLED = "log.errorevent.enabled";
     private static final String API_BYPASSWORD = "server.api.bypassword";
     private static final String STATS_UPDATE_INTERVAL = "donkey.statsupdateinterval";
     private static final String RHINO_LANGUAGE_VERSION = "rhino.languageversion";
@@ -343,6 +346,16 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
             if (StringUtils.isNotBlank(deploy)) {
                 startupDeploy = Boolean.parseBoolean(deploy);
             }
+
+            /*
+             * Channel-aware logging toggles (opt-in; default false preserves legacy behavior).
+             * Both are read here and pushed into the donkey module's LogContext, which cannot read
+             * mirth.properties directly. LogContext is the single source of truth consulted by
+             * LogContext/ArrayAppender (channel context) and by DefaultEventController +
+             * DestinationConnector (error-event logging).
+             */
+            LogContext.setEnabled(mirthConfig.getBoolean(LOG_CHANNEL_CONTEXT_ENABLED, false));
+            LogContext.setErrorEventLoggingEnabled(mirthConfig.getBoolean(LOG_ERROR_EVENT_ENABLED, false));
 
             // Check for server GUID and generate a new one if it doesn't exist
             File serverIdFile = new File(getApplicationDataDir(), "server.id");

--- a/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
@@ -159,6 +159,11 @@ public class DefaultEventController extends EventController {
      * with identical values when they did).
      */
     private void logErrorEvent(ErrorEvent event) {
+        // Opt-in (log.errorevent.enabled). When off, connector/transformer errors stay out of
+        // mirth.log (legacy behavior); they remain visible in the in-app Server Log.
+        if (!LogContext.isErrorEventLoggingEnabled()) {
+            return;
+        }
         try (LogContext.Scope channelScope = event.getChannelId() != null
                                              ? LogContext.channel(event.getChannelId(), null) : null;
              LogContext.Scope connectorScope = (event.getMetaDataId() != null && event.getConnectorName() != null)

--- a/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
@@ -31,6 +31,7 @@ import com.mirth.connect.donkey.server.event.DeployedStateEvent;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.server.event.EventType;
 import com.mirth.connect.donkey.server.event.MessageEvent;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.model.ServerEvent;
 import com.mirth.connect.model.filters.EventFilter;
 import com.mirth.connect.server.ExtensionLoader;
@@ -42,6 +43,14 @@ import com.mirth.connect.server.util.SqlConfig;
 
 public class DefaultEventController extends EventController {
     private Logger logger = LogManager.getLogger(this.getClass());
+
+    /**
+     * Dedicated logger for ErrorEvent dispatches. Every connector/transformer that catches
+     * an exception and dispatches an ErrorEvent (HTTP/TCP/JMS/JDBC sender, response transformer,
+     * etc.) is funneled through this logger so mirth.log carries a record of every error
+     * surfaced in the in-app Server Log.
+     */
+    private static final Logger eventErrorLogger = LogManager.getLogger("event.error");
 
     private static EventController instance = null;
 
@@ -123,6 +132,7 @@ public class DefaultEventController extends EventController {
             if (event instanceof MessageEvent) {
                 queues = messageEventQueues;
             } else if (event instanceof ErrorEvent) {
+                logErrorEvent((ErrorEvent) event);
                 queues = errorEventQueues;
             } else if (event instanceof DeployedStateEvent) {
                 queues = deployedStateEventQueues;
@@ -139,6 +149,31 @@ public class DefaultEventController extends EventController {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Writes a structured one-line ERROR entry to mirth.log for every ErrorEvent. The caller
+     * thread typically already has channel/connector/message MDC set (via LogContext); the
+     * scopes opened here back-fill any keys the caller didn't set (and harmlessly overwrite
+     * with identical values when they did).
+     */
+    private void logErrorEvent(ErrorEvent event) {
+        try (LogContext.Scope channelScope = event.getChannelId() != null
+                                             ? LogContext.channel(event.getChannelId(), null) : null;
+             LogContext.Scope connectorScope = (event.getMetaDataId() != null && event.getConnectorName() != null)
+                                              ? LogContext.connector(event.getConnectorName(), event.getMetaDataId()) : null;
+             LogContext.Scope messageScope = event.getMessageId() != null
+                                            ? LogContext.message(event.getMessageId()) : null) {
+            String msg = event.getCustomMessage();
+            if (msg == null) {
+                msg = event.getType() != null ? event.getType().toString() : "Error event";
+            }
+            if (event.getThrowable() != null) {
+                eventErrorLogger.error(msg, event.getThrowable());
+            } else {
+                eventErrorLogger.error(msg);
+            }
         }
     }
 

--- a/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultEventController.java
@@ -31,7 +31,6 @@ import com.mirth.connect.donkey.server.event.DeployedStateEvent;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.server.event.EventType;
 import com.mirth.connect.donkey.server.event.MessageEvent;
-import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.model.ServerEvent;
 import com.mirth.connect.model.filters.EventFilter;
 import com.mirth.connect.server.ExtensionLoader;
@@ -43,14 +42,6 @@ import com.mirth.connect.server.util.SqlConfig;
 
 public class DefaultEventController extends EventController {
     private Logger logger = LogManager.getLogger(this.getClass());
-
-    /**
-     * Dedicated logger for ErrorEvent dispatches. Every connector/transformer that catches
-     * an exception and dispatches an ErrorEvent (HTTP/TCP/JMS/JDBC sender, response transformer,
-     * etc.) is funneled through this logger so mirth.log carries a record of every error
-     * surfaced in the in-app Server Log.
-     */
-    private static final Logger eventErrorLogger = LogManager.getLogger("event.error");
 
     private static EventController instance = null;
 
@@ -132,7 +123,6 @@ public class DefaultEventController extends EventController {
             if (event instanceof MessageEvent) {
                 queues = messageEventQueues;
             } else if (event instanceof ErrorEvent) {
-                logErrorEvent((ErrorEvent) event);
                 queues = errorEventQueues;
             } else if (event instanceof DeployedStateEvent) {
                 queues = deployedStateEventQueues;
@@ -149,36 +139,6 @@ public class DefaultEventController extends EventController {
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-        }
-    }
-
-    /**
-     * Writes a structured one-line ERROR entry to mirth.log for every ErrorEvent. The caller
-     * thread typically already has channel/connector/message MDC set (via LogContext); the
-     * scopes opened here back-fill any keys the caller didn't set (and harmlessly overwrite
-     * with identical values when they did).
-     */
-    private void logErrorEvent(ErrorEvent event) {
-        // Opt-in (log.errorevent.enabled). When off, connector/transformer errors stay out of
-        // mirth.log (legacy behavior); they remain visible in the in-app Server Log.
-        if (!LogContext.isErrorEventLoggingEnabled()) {
-            return;
-        }
-        try (LogContext.Scope channelScope = event.getChannelId() != null
-                                             ? LogContext.channel(event.getChannelId(), null) : null;
-             LogContext.Scope connectorScope = (event.getMetaDataId() != null && event.getConnectorName() != null)
-                                              ? LogContext.connector(event.getConnectorName(), event.getMetaDataId()) : null;
-             LogContext.Scope messageScope = event.getMessageId() != null
-                                            ? LogContext.message(event.getMessageId()) : null) {
-            String msg = event.getCustomMessage();
-            if (msg == null) {
-                msg = event.getType() != null ? event.getType().toString() : "Error event";
-            }
-            if (event.getThrowable() != null) {
-                eventErrorLogger.error(msg, event.getThrowable());
-            } else {
-                eventErrorLogger.error(msg);
-            }
         }
     }
 

--- a/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
+++ b/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
@@ -1976,10 +1976,12 @@ public class DonkeyEngineController implements EngineController {
                         t = e.getCause();
                     }
 
-                    if (LogContext.isErrorEventLoggingEnabled()) {
-                        logger.error("Error running channel deploy script", t);
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channel.getName())) {
+                        if (LogContext.isErrorEventLoggingEnabled()) {
+                            logger.error("Error running channel deploy script", t);
+                        }
+                        eventController.dispatchEvent(new ErrorEvent(channelModel.getId(), null, null, ErrorEventType.DEPLOY_SCRIPT, null, null, "Error running channel deploy script", t));
                     }
-                    eventController.dispatchEvent(new ErrorEvent(channelModel.getId(), null, null, ErrorEventType.DEPLOY_SCRIPT, null, null, "Error running channel deploy script", t));
                     throw new DeployException("Failed to deploy channel " + channelId + ".", e);
                 }
 
@@ -2144,8 +2146,10 @@ public class DonkeyEngineController implements EngineController {
                         t = e.getCause();
                     }
 
-                    eventController.dispatchEvent(new ErrorEvent(channelId, null, null, ErrorEventType.UNDEPLOY_SCRIPT, null, null, "Error running channel undeploy script", t));
-                    logger.error("Error executing undeploy script for channel " + channelId + ".", e);
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channel.getName())) {
+                        eventController.dispatchEvent(new ErrorEvent(channelId, null, null, ErrorEventType.UNDEPLOY_SCRIPT, null, null, "Error running channel undeploy script", t));
+                        logger.error("Error executing undeploy script for channel " + channelId + ".", e);
+                    }
                 
                 }
 	            

--- a/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
+++ b/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
@@ -85,6 +85,7 @@ import com.mirth.connect.donkey.server.channel.components.PreProcessor;
 import com.mirth.connect.donkey.server.data.DonkeyDao;
 import com.mirth.connect.donkey.server.data.buffered.BufferedDaoFactory;
 import com.mirth.connect.donkey.server.data.passthru.PassthruDaoFactory;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.donkey.server.event.EventDispatcher;
 import com.mirth.connect.donkey.server.message.DataType;
@@ -1975,6 +1976,9 @@ public class DonkeyEngineController implements EngineController {
                         t = e.getCause();
                     }
 
+                    if (LogContext.isErrorEventLoggingEnabled()) {
+                        logger.error("Error running channel deploy script", t);
+                    }
                     eventController.dispatchEvent(new ErrorEvent(channelModel.getId(), null, null, ErrorEventType.DEPLOY_SCRIPT, null, null, "Error running channel deploy script", t));
                     throw new DeployException("Failed to deploy channel " + channelId + ".", e);
                 }

--- a/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
+++ b/server/src/com/mirth/connect/server/controllers/DonkeyEngineController.java
@@ -1976,12 +1976,11 @@ public class DonkeyEngineController implements EngineController {
                         t = e.getCause();
                     }
 
-                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channel.getName())) {
-                        if (LogContext.isErrorEventLoggingEnabled()) {
-                            logger.error("Error running channel deploy script", t);
-                        }
-                        eventController.dispatchEvent(new ErrorEvent(channelModel.getId(), null, null, ErrorEventType.DEPLOY_SCRIPT, null, null, "Error running channel deploy script", t));
-                    }
+                    // Deploy-script failures are already logged by JavaScriptUtil (detailed error)
+                    // and by the ChannelTask error handler (deploy outcome, with channel context),
+                    // so we don't log again here. The ErrorEvent is still dispatched for alerts /
+                    // the in-app Server Log.
+                    eventController.dispatchEvent(new ErrorEvent(channelModel.getId(), null, null, ErrorEventType.DEPLOY_SCRIPT, null, null, "Error running channel deploy script", t));
                     throw new DeployException("Failed to deploy channel " + channelId + ".", e);
                 }
 

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptFilterTransformer.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptFilterTransformer.java
@@ -25,6 +25,7 @@ import com.mirth.connect.donkey.server.channel.Channel;
 import com.mirth.connect.donkey.server.channel.Connector;
 import com.mirth.connect.donkey.server.channel.DestinationConnector;
 import com.mirth.connect.donkey.server.channel.FilterTransformerResult;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.channel.SourceConnector;
 import com.mirth.connect.donkey.server.channel.components.FilterTransformer;
 import com.mirth.connect.donkey.server.channel.components.FilterTransformerException;
@@ -195,6 +196,9 @@ public class JavaScriptFilterTransformer implements FilterTransformer {
         @Override
         public FilterTransformerResult doCall() throws Exception {
             Logger scriptLogger = LogManager.getLogger("filter");
+            try (LogContext.Scope channelScope = LogContext.channel(connector.getChannelId(), connector.getChannel() != null ? connector.getChannel().getName() : null);
+                 LogContext.Scope connectorScope = LogContext.connector(connectorName, connector.getMetaDataId());
+                 LogContext.Scope messageScope = LogContext.message(message.getMessageId())) {
             // Use an array to store the phase, otherwise java and javascript end up referencing two different objects.
             String[] phase = { new String() };
 
@@ -227,27 +231,41 @@ public class JavaScriptFilterTransformer implements FilterTransformer {
 
                     return new FilterTransformerResult(!(Boolean) Context.jsToJava(result, java.lang.Boolean.class), transformedData);
                 } catch (Throwable t) {
+                    int errorLine = -1;
+                    String errorDetails = null;
                     if (t instanceof RhinoException) {
+                        RhinoException re = (RhinoException) t;
+                        errorLine = re.lineNumber();
+                        errorDetails = re.details();
                         try {
                             String script = CompiledScriptCache.getInstance().getSourceScript(scriptId);
-                            int linenumber = ((RhinoException) t).lineNumber();
-                            String errorReport = JavaScriptUtil.getSourceCode(script, linenumber, 0);
-                            t = new MirthJavascriptTransformerException((RhinoException) t, connector.getChannelId(), connectorName, 0, phase[0].toUpperCase(), errorReport);
+                            String errorReport = JavaScriptUtil.getSourceCode(script, errorLine, 0);
+                            t = new MirthJavascriptTransformerException(re, connector.getChannelId(), connectorName, 0, phase[0].toUpperCase(), errorReport);
                         } catch (Exception ee) {
-                            t = new MirthJavascriptTransformerException((RhinoException) t, connector.getChannelId(), connectorName, 0, phase[0].toUpperCase(), null);
+                            t = new MirthJavascriptTransformerException(re, connector.getChannelId(), connectorName, 0, phase[0].toUpperCase(), null);
                         }
                     }
 
-                    if (phase[0].equals("filter")) {
-                        eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), message.getMetaDataId(), message.getMessageId(), ErrorEventType.FILTER, connectorName, null, "Error evaluating filter", t));
-                        throw new FilterTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.FILTER.toString(), "Error evaluating filter", t));
-                    } else {
-                        eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), message.getMetaDataId(), message.getMessageId(), ErrorEventType.TRANSFORMER, connectorName, null, "Error evaluating transformer", t));
-                        throw new FilterTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.TRANSFORMER.toString(), "Error evaluating transformer", t));
+                    String errPhase = phase[0].isEmpty() ? "UNKNOWN" : phase[0].toUpperCase();
+                    String oneLineMsg = "Error evaluating " + (phase[0].isEmpty() ? "script" : phase[0])
+                            + (errorDetails != null ? ": " + errorDetails : "");
+
+                    // Logging is done by DefaultEventController.dispatchEvent when the ErrorEvent
+                    // is dispatched below — that centralizes error logging across all connectors.
+                    // We keep scriptPhase/scriptLine in MDC so the central log line carries them.
+                    try (LogContext.Scope scriptScope = LogContext.script(errPhase, errorLine)) {
+                        if (phase[0].equals("filter")) {
+                            eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), message.getMetaDataId(), message.getMessageId(), ErrorEventType.FILTER, connectorName, null, oneLineMsg, t));
+                            throw new FilterTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.FILTER.toString(), "Error evaluating filter", t));
+                        } else {
+                            eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), message.getMetaDataId(), message.getMessageId(), ErrorEventType.TRANSFORMER, connectorName, null, oneLineMsg, t));
+                            throw new FilterTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.TRANSFORMER.toString(), "Error evaluating transformer", t));
+                        }
                     }
                 } finally {
                     Context.exit();
                 }
+            }
             }
         }
     }

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptFilterTransformer.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptFilterTransformer.java
@@ -250,10 +250,13 @@ public class JavaScriptFilterTransformer implements FilterTransformer {
                     String oneLineMsg = "Error evaluating " + (phase[0].isEmpty() ? "script" : phase[0])
                             + (errorDetails != null ? ": " + errorDetails : "");
 
-                    // Logging is done by DefaultEventController.dispatchEvent when the ErrorEvent
-                    // is dispatched below — that centralizes error logging across all connectors.
-                    // We keep scriptPhase/scriptLine in MDC so the central log line carries them.
+                    // Opt-in error logging (log.errorevent.enabled). The script scope puts
+                    // scriptPhase/scriptLine on the line. The ErrorEvent is still dispatched below
+                    // for the in-app Server Log and alerts regardless of the toggle.
                     try (LogContext.Scope scriptScope = LogContext.script(errPhase, errorLine)) {
+                        if (LogContext.isErrorEventLoggingEnabled()) {
+                            scriptLogger.error(oneLineMsg, t);
+                        }
                         if (phase[0].equals("filter")) {
                             eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), message.getMetaDataId(), message.getMessageId(), ErrorEventType.FILTER, connectorName, null, oneLineMsg, t));
                             throw new FilterTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.FILTER.toString(), "Error evaluating filter", t));

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptPostprocessor.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptPostprocessor.java
@@ -159,7 +159,7 @@ public class JavaScriptPostprocessor implements PostProcessor {
                     debugger.setVisible(true);
                 }
             }
-            return JavaScriptUtil.executePostprocessorScripts(this, message);
+            return JavaScriptUtil.executePostprocessorScripts(this, message, channel.getName());
         }
     }
 }

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptPostprocessor.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptPostprocessor.java
@@ -24,6 +24,7 @@ import com.mirth.connect.donkey.model.message.Message;
 import com.mirth.connect.donkey.model.message.Response;
 import com.mirth.connect.donkey.server.channel.Channel;
 import com.mirth.connect.donkey.server.channel.components.PostProcessor;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.model.codetemplates.ContextType;
 import com.mirth.connect.server.MirthJavascriptTransformerException;
@@ -127,6 +128,9 @@ public class JavaScriptPostprocessor implements PostProcessor {
                 t = e.getCause();
             }
 
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error running postprocessor scripts", t);
+            }
             eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), null, message.getMessageId(), ErrorEventType.POSTPROCESSOR_SCRIPT, null, null, "Error running postprocessor scripts", t));
             throw new DonkeyException(t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.POSTPROCESSOR_SCRIPT.toString(), "Error running postprocessor scripts", t));
         }

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptPreprocessor.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptPreprocessor.java
@@ -169,7 +169,7 @@ public class JavaScriptPreprocessor implements PreProcessor {
                     debugger.setVisible(true);
                 }
             }
-            return JavaScriptUtil.executePreprocessorScripts(this, message, channel.getSourceConnector().getDestinationIdMap(), this.scopeProvider);
+            return JavaScriptUtil.executePreprocessorScripts(this, message, channel.getSourceConnector().getDestinationIdMap(), this.scopeProvider, channel.getName());
         }
     }
 }

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptPreprocessor.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptPreprocessor.java
@@ -23,6 +23,7 @@ import com.mirth.connect.donkey.model.event.ErrorEventType;
 import com.mirth.connect.donkey.model.message.ConnectorMessage;
 import com.mirth.connect.donkey.server.channel.Channel;
 import com.mirth.connect.donkey.server.channel.components.PreProcessor;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
 import com.mirth.connect.model.codetemplates.ContextType;
 import com.mirth.connect.server.MirthJavascriptTransformerException;
@@ -130,6 +131,9 @@ public class JavaScriptPreprocessor implements PreProcessor {
                 t = e.getCause();
             }
 
+            if (LogContext.isErrorEventLoggingEnabled()) {
+                logger.error("Error running preprocessor scripts", t);
+            }
             eventController.dispatchEvent(new ErrorEvent(message.getChannelId(), null, message.getMessageId(), ErrorEventType.PREPROCESSOR_SCRIPT, null, null, "Error running preprocessor scripts", t));
             throw new DonkeyException(t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.PREPROCESSOR_SCRIPT.toString(), "Error running preprocessor scripts", t));
         }

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptResponseTransformer.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptResponseTransformer.java
@@ -23,6 +23,7 @@ import com.mirth.connect.donkey.model.event.ErrorEventType;
 import com.mirth.connect.donkey.model.message.ConnectorMessage;
 import com.mirth.connect.donkey.model.message.Response;
 import com.mirth.connect.donkey.server.channel.Connector;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.server.channel.components.ResponseTransformer;
 import com.mirth.connect.donkey.server.channel.components.ResponseTransformerException;
 import com.mirth.connect.donkey.server.event.ErrorEvent;
@@ -185,6 +186,9 @@ public class JavaScriptResponseTransformer implements ResponseTransformer {
         @Override
         public String doCall() throws Exception {
             Logger scriptLogger = LogManager.getLogger("response");
+            try (LogContext.Scope channelScope = LogContext.channel(connector.getChannelId(), connector.getChannel() != null ? connector.getChannel().getName() : null);
+                 LogContext.Scope connectorScope = LogContext.connector(connectorName, connector.getMetaDataId());
+                 LogContext.Scope messageScope = LogContext.message(connectorMessage.getMessageId())) {
 
             // Get the script from the cache
             Script compiledScript = compiledScriptCache.getCompiledScript(scriptId);
@@ -223,22 +227,35 @@ public class JavaScriptResponseTransformer implements ResponseTransformer {
                     // Return the result
                     return JavaScriptScopeUtil.getTransformedDataFromScope(scope, StringUtils.isNotBlank(template));
                 } catch (Throwable t) {
+                    int errorLine = -1;
+                    String errorDetails = null;
                     if (t instanceof RhinoException) {
+                        RhinoException re = (RhinoException) t;
+                        errorLine = re.lineNumber();
+                        errorDetails = re.details();
                         try {
                             String script = CompiledScriptCache.getInstance().getSourceScript(scriptId);
-                            int linenumber = ((RhinoException) t).lineNumber();
-                            String errorReport = JavaScriptUtil.getSourceCode(script, linenumber, 0);
-                            t = new MirthJavascriptTransformerException((RhinoException) t, connector.getChannelId(), connectorName, 0, "response", errorReport);
+                            String errorReport = JavaScriptUtil.getSourceCode(script, errorLine, 0);
+                            t = new MirthJavascriptTransformerException(re, connector.getChannelId(), connectorName, 0, "response", errorReport);
                         } catch (Exception ee) {
-                            t = new MirthJavascriptTransformerException((RhinoException) t, connector.getChannelId(), connectorName, 0, "response", null);
+                            t = new MirthJavascriptTransformerException(re, connector.getChannelId(), connectorName, 0, "response", null);
                         }
                     }
 
-                    eventController.dispatchEvent(new ErrorEvent(connectorMessage.getChannelId(), connectorMessage.getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.RESPONSE_TRANSFORMER, connectorName, null, "Error evaluating response transformer", t));
-                    throw new ResponseTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.RESPONSE_TRANSFORMER.toString(), "Error evaluating response transformer", t));
+                    String oneLineMsg = "Error evaluating response transformer"
+                            + (errorDetails != null ? ": " + errorDetails : "");
+
+                    // Logging is centralized in DefaultEventController.dispatchEvent. We open a
+                    // script scope so scriptPhase/scriptLine MDC keys are present on the
+                    // resulting log line.
+                    try (LogContext.Scope scriptScope = LogContext.script("RESPONSE", errorLine)) {
+                        eventController.dispatchEvent(new ErrorEvent(connectorMessage.getChannelId(), connectorMessage.getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.RESPONSE_TRANSFORMER, connectorName, null, oneLineMsg, t));
+                        throw new ResponseTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.RESPONSE_TRANSFORMER.toString(), "Error evaluating response transformer", t));
+                    }
                 } finally {
                     Context.exit();
                 }
+            }
             }
         }
 

--- a/server/src/com/mirth/connect/server/transformers/JavaScriptResponseTransformer.java
+++ b/server/src/com/mirth/connect/server/transformers/JavaScriptResponseTransformer.java
@@ -245,10 +245,14 @@ public class JavaScriptResponseTransformer implements ResponseTransformer {
                     String oneLineMsg = "Error evaluating response transformer"
                             + (errorDetails != null ? ": " + errorDetails : "");
 
-                    // Logging is centralized in DefaultEventController.dispatchEvent. We open a
-                    // script scope so scriptPhase/scriptLine MDC keys are present on the
-                    // resulting log line.
+                    // Opt-in error logging (log.errorevent.enabled). Logged here (inside the script
+                    // scope, so scriptPhase/scriptLine are on the line) when enabled; when disabled,
+                    // DestinationConnector logs the response-transformer failure instead (legacy
+                    // behavior). The ErrorEvent is dispatched regardless for the in-app Server Log.
                     try (LogContext.Scope scriptScope = LogContext.script("RESPONSE", errorLine)) {
+                        if (LogContext.isErrorEventLoggingEnabled()) {
+                            scriptLogger.error(oneLineMsg, t);
+                        }
                         eventController.dispatchEvent(new ErrorEvent(connectorMessage.getChannelId(), connectorMessage.getMetaDataId(), connectorMessage.getMessageId(), ErrorEventType.RESPONSE_TRANSFORMER, connectorName, null, oneLineMsg, t));
                         throw new ResponseTransformerException(t.getMessage(), t, ErrorMessageBuilder.buildErrorMessage(ErrorEventType.RESPONSE_TRANSFORMER.toString(), "Error evaluating response transformer", t));
                     }

--- a/server/src/com/mirth/connect/server/util/javascript/JavaScriptUtil.java
+++ b/server/src/com/mirth/connect/server/util/javascript/JavaScriptUtil.java
@@ -42,6 +42,7 @@ import com.mirth.connect.donkey.model.message.Response;
 import com.mirth.connect.donkey.model.message.Status;
 import com.mirth.connect.donkey.model.message.attachment.AttachmentException;
 import com.mirth.connect.donkey.server.ConnectorTaskException;
+import com.mirth.connect.donkey.server.channel.LogContext;
 import com.mirth.connect.donkey.util.Base64Util;
 import com.mirth.connect.model.Channel;
 import com.mirth.connect.model.ServerEvent;
@@ -111,12 +112,12 @@ public class JavaScriptUtil {
         String processedMessage = message.getRawData();
         Object result = null;
 
-        try {
+        try (LogContext.Scope outerChannelScope = LogContext.channel(channelId, channelName)) {
             result = execute(new JavaScriptTask<Object>(contextFactory, ScriptController.ATTACHMENT_SCRIPT_KEY, channelId, channelName) {
                 @Override
                 public Object doCall() throws Exception {
                     Logger scriptLogger = LogManager.getLogger(ScriptController.ATTACHMENT_SCRIPT_KEY.toLowerCase());
-                    try {
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName)) {
                         Scriptable scope = JavaScriptScopeUtil.getAttachmentScope(getContextFactory(), scriptLogger, channelId, channelName, finalMessage, attachments, isBinary);
                         return JavaScriptUtil.executeScript(this, ScriptController.getScriptId(ScriptController.ATTACHMENT_SCRIPT_KEY, channelId), scope, null, null);
                     } finally {
@@ -170,6 +171,12 @@ public class JavaScriptUtil {
      * 
      */
     public static String executePreprocessorScripts(JavaScriptTask<Object> task, ConnectorMessage message, Map<String, Integer> destinationIdMap, MirthScopeProvider scopeProvider) throws Exception {
+        return executePreprocessorScripts(task, message, destinationIdMap, scopeProvider, null);
+    }
+
+    public static String executePreprocessorScripts(JavaScriptTask<Object> task, ConnectorMessage message, Map<String, Integer> destinationIdMap, MirthScopeProvider scopeProvider, String channelName) throws Exception {
+        try (LogContext.Scope channelScope = LogContext.channel(message.getChannelId(), channelName);
+             LogContext.Scope messageScope = LogContext.message(message.getMessageId())) {
         String processedMessage = null;
         String globalResult = message.getRaw().getContent();
         Logger scriptLogger = LogManager.getLogger(ScriptController.PREPROCESSOR_SCRIPT_KEY.toLowerCase());
@@ -240,6 +247,7 @@ public class JavaScriptUtil {
         }
 
         return processedMessage;
+        }
     }
 
     /**
@@ -271,6 +279,12 @@ public class JavaScriptUtil {
      * @throws Exception
      */
     public static Response executePostprocessorScripts(JavaScriptTask<Object> task, Message message) throws Exception {
+        return executePostprocessorScripts(task, message, null);
+    }
+
+    public static Response executePostprocessorScripts(JavaScriptTask<Object> task, Message message, String channelName) throws Exception {
+        try (LogContext.Scope channelScope = LogContext.channel(message.getChannelId(), channelName);
+             LogContext.Scope messageScope = LogContext.message(message.getMessageId())) {
         Logger scriptLogger = LogManager.getLogger(ScriptController.POSTPROCESSOR_SCRIPT_KEY.toLowerCase());
 
         Response channelResponse = null;
@@ -312,6 +326,7 @@ public class JavaScriptUtil {
         }
 
         return response;
+        }
     }
 
     private static Response getPostprocessorResponse(Object result) {
@@ -378,12 +393,12 @@ public class JavaScriptUtil {
      * @throws JavaScriptExecutorException
      */
     public static void executeChannelDebugDeployScript(MirthContextFactory contextFactory, final String scriptId, final String scriptType, final String channelId, final String channelName, MirthScopeProvider scopeProvider) throws InterruptedException, JavaScriptExecutorException {
-        try {
+        try (LogContext.Scope outerChannelScope = LogContext.channel(channelId, channelName)) {
             execute(new JavaScriptTask<Object>(contextFactory, scriptType, channelId, channelName) {
                 @Override
                 public Object doCall() throws Exception {
                     Logger scriptLogger = LogManager.getLogger(scriptType.toLowerCase());
-                    try {
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName)) {
                         Scriptable scope = JavaScriptScopeUtil.getDeployScope(getContextFactory(), scriptLogger, channelId, channelName);
                         scopeProvider.setScope(scope);
                         JavaScriptUtil.executeScript(this, scriptId, scope, channelId, null);
@@ -409,12 +424,12 @@ public class JavaScriptUtil {
      * @throws JavaScriptExecutorException
      */
     public static void executeChannelDeployScript(MirthContextFactory contextFactory, final String scriptId, final String scriptType, final String channelId, final String channelName) throws InterruptedException, JavaScriptExecutorException {
-        try {
+        try (LogContext.Scope outerChannelScope = LogContext.channel(channelId, channelName)) {
             execute(new JavaScriptTask<Object>(contextFactory, scriptType, channelId, channelName) {
                 @Override
                 public Object doCall() throws Exception {
                     Logger scriptLogger = LogManager.getLogger(scriptType.toLowerCase());
-                    try {
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName)) {
                         Scriptable scope = JavaScriptScopeUtil.getDeployScope(getContextFactory(), scriptLogger, channelId, channelName);
                         JavaScriptUtil.executeScript(this, scriptId, scope, channelId, null);
                         return null;
@@ -439,12 +454,12 @@ public class JavaScriptUtil {
      * @throws JavaScriptExecutorException
      */
     public static void executeChannelUndeployScript(MirthContextFactory contextFactory, final String scriptId, final String scriptType, final String channelId, final String channelName) throws InterruptedException, JavaScriptExecutorException {
-        try {
+        try (LogContext.Scope outerChannelScope = LogContext.channel(channelId, channelName)) {
             execute(new JavaScriptTask<Object>(contextFactory, scriptType, channelId, channelName) {
                 @Override
                 public Object doCall() throws Exception {
                     Logger scriptLogger = LogManager.getLogger(scriptType.toLowerCase());
-                    try {
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName)) {
                         Scriptable scope = JavaScriptScopeUtil.getUndeployScope(getContextFactory(), scriptLogger, channelId, channelName);
                         JavaScriptUtil.executeScript(this, scriptId, scope, channelId, null);
                         return null;
@@ -471,12 +486,12 @@ public class JavaScriptUtil {
      * @throws JavaScriptExecutorException
      */
     public static void executeChannelDebugUndeployScript(MirthContextFactory contextFactory, final String scriptId, final String scriptType, final String channelId, final String channelName, MirthScopeProvider scopeProvider) throws InterruptedException, JavaScriptExecutorException {
-        try {
+        try (LogContext.Scope outerChannelScope = LogContext.channel(channelId, channelName)) {
             execute(new JavaScriptTask<Object>(contextFactory, scriptType, channelId, channelName) {
                 @Override
                 public Object doCall() throws Exception {
                     Logger scriptLogger = LogManager.getLogger(scriptType.toLowerCase());
-                    try {
+                    try (LogContext.Scope channelScope = LogContext.channel(channelId, channelName)) {
                         Scriptable scope = JavaScriptScopeUtil.getUndeployScope(getContextFactory(), scriptLogger, channelId, channelName);
                         scopeProvider.setScope(scope);
                         JavaScriptUtil.executeScript(this, scriptId, scope, channelId, null);


### PR DESCRIPTION
## Summary

Three related changes that make BridgeLink logs aggregator-ready and the in-app Server Log channel-aware. **All three are opt-in and default off** — see [Opt-in by default](#opt-in-by-default) below, so this PR is a no-op for existing installs until the toggles are enabled.

1. **Channel/connector/message context in every log line.** A new `LogContext` helper (donkey module) wraps Log4j2's `ThreadContext` (MDC) with try-with-resources scopes that record and restore prior values on close, so pooled threads can't leak context between unrelated work units. The MDC is populated at every channel-work entry point: `Channel.run()`, source/destination connector dispatch and queue threads, recovery, admin tasks (`ChannelTask`), and JavaScript filter/transformer/response/preprocessor/postprocessor execution. The log4j2 pattern renders each MDC field as a `key=value` token, wrapped in `%notEmpty{...}` so non-channel lines (server startup, etc.) — and all lines when the feature is off — stay clean.

   Result: when `log.channelcontext.enabled=true`, every channel-scoped line in `mirth.log` looks like
   ```
   ERROR 2026-05-14 ... [thread] channelId=… channelName=test metaDataId=1 connectorName=HTTP Sender messageId=42 scriptPhase=FILTER scriptLine=101 event.error: …
   ```

2. **Centralized `ErrorEvent` → `mirth.log` handler — fixes [nextgenhealthcare/connect#5524](https://github.com/nextgenhealthcare/connect/issues/5524).** A single synchronous interceptor in `DefaultEventController.dispatchEvent` writes one ERROR row per dispatched `ErrorEvent`. With this enabled, errors from every connector dispatcher (HTTP/TCP/JMS/JDBC/File/SMTP/WS/etc.) and from the JavaScript filter/transformer/response transformer surface in `mirth.log` the same way they already appeared in the BridgeLink in-app Server Log. JavaScript filter/transformer/response catch blocks also extract the Rhino phase/line/details into MDC and into the ErrorEvent `customMessage` so the resulting log row carries the actionable details a log aggregator needs to facet on. The two `DestinationConnector` response-transformer `logger.error` calls are retained but guarded by the toggle, so they fire only when centralized logging is off — preserving exact pre-PR logging when disabled and avoiding double-logging when enabled.

3. **In-app Server Log filters by selected channel(s).** Mirroring how Connection Log and Global Maps already do this: select one or more channels on the Dashboard → Server Log narrows to those channels' rows plus system rows (no channel context — startup, FATAL, etc.). Deselect → unified view. Server-side per-channel buffers (matching `DefaultConnectionLogController`) prevent a noisy channel from evicting a quiet channel's history. The Server Log appender (`ArrayAppender`) also prepends a human-readable `[channel=name, connector=…, msgId=…]` to messages going to the in-app tab. (Depends on the channel context from (1); with that off, the filter falls back to the unified view.)

## Opt-in by default

All behavior changes are gated behind two `mirth.properties` options, **both default `false`**, so existing installs see identical logs after upgrade and opt in only when ready:

| Property | Gates | Default |
|---|---|---|
| `log.channelcontext.enabled` | (1) MDC enrichment of log lines + the Dashboard Server Log channel filter | `false` |
| `log.errorevent.enabled` | (2) centralized `ErrorEvent` → `mirth.log` | `false` |

- With `log.channelcontext.enabled=false`, `LogContext` factories return a no-op scope and write no MDC keys, so the `%notEmpty{…}` pattern stays inert and `mirth.log` lines are byte-identical to the pre-PR format — existing log-parsing/aggregation rules are unaffected. The `log4j2.properties` pattern change is harmless when the MDC is empty.
- With `log.errorevent.enabled=false`, connector/transformer errors stay out of `mirth.log` (still visible in the in-app Server Log), matching legacy volume.
- `LogContext` (donkey) holds both flags as the single source of truth; the server reads the properties in `DefaultConfigurationController.loadProperties()` and pushes them down via setters (avoiding a server-on-donkey dependency). `DefaultServerLogController` falls back to the unified buffer when channel context is off, so a channel-filtered Server Log can never show an empty pane.

## Files touched

- New: `donkey/.../LogContext.java` + `LogContextTest.java` (11 JUnit tests, incl. the disabled no-op path)
- Donkey: `Channel.java`, `SourceConnector.java`, `DestinationConnector.java`, `RecoveryTask.java`
- Server: `log4j2.properties`, `ChannelTask.java`, `DefaultEventController.java`, `JavaScriptFilterTransformer.java`, `JavaScriptResponseTransformer.java`, `JavaScriptPreprocessor.java`, `JavaScriptPostprocessor.java`, `JavaScriptUtil.java`, `ArrayAppender.java`
- Server log plugin (channel filter): `ServerLogItem.java`, `ServerLogProvider.java`, `ServerLogController.java`, `DefaultServerLogController.java`, `ServerLogServletInterface.java`, `ServerLogServlet.java`
- Client: `ServerLogClient.java`
- Toggles: `server/conf/mirth.properties` (two documented options), `DefaultConfigurationController.java` (reads + pushes them into `LogContext`)

## Test plan

- [ ] `cd server && ant -f mirth-build.xml` builds clean
- [ ] `donkey/.../LogContextTest` — 11/11 pass
- [ ] Start the dev server. Log in as `admin`/`admin`. Deploy 2–3 channels, send messages through each.

**Default (both toggles off) — must equal pre-PR behavior**
- [ ] `mirth.log` channel lines carry **no** `channelId=…/connectorName=…` tokens (legacy format).
- [ ] Misconfigure an HTTP Sender (unreachable host) → connector error does **not** appear in `mirth.log` (only in the in-app Server Log).
- [ ] Force a response-transformer exception → it **does** still appear in `mirth.log` exactly once (guarded fallback).
- [ ] Dashboard → Server Log: selecting a channel still shows entries (unified view; never empty).

**`log.channelcontext.enabled=true`**
- [ ] `mirth.log` lines for channel work carry `channelId=… channelName=… connectorName=… messageId=…` as parseable tokens.
- [ ] Throw an exception from a source / destination / response transformer — the resulting line includes `scriptPhase=…` and `scriptLine=…`.
- [ ] In BridgeLink Administrator: open the Dashboard → Server Log tab.
  - [ ] No channel selected → unified view.
  - [ ] Select one channel → only that channel's rows plus system rows.
  - [ ] Select a quiet channel after a noisy one has flooded the buffer → quiet channel's older history is still visible (per-channel buffers).
  - [ ] Shift-select multiple channels → union plus system rows.
  - [ ] Deselect everything → unified view returns.
- [ ] REST sanity: `curl -sk -b cookies "https://localhost:8443/api/extensions/serverlog?fetchSize=20&channelId=<id>"` returns only that channel's rows + system rows.

**`log.errorevent.enabled=true`**
- [ ] Misconfigure an HTTP Sender → a structured ERROR row lands in `mirth.log` (previously only visible in the in-app Server Log).
- [ ] Response-transformer error is logged exactly once (no duplicate from the guarded fallback).

## Compatibility notes

- Both features are **opt-in (default off)**; an upgrade changes nothing until the operator sets the toggles. See [Opt-in by default](#opt-in-by-default).
- `ServerLogItem` gains a nullable `channelId` field; the prior 9-arg constructor is retained so callers like `SwaggerExamplesServlet` continue to compile.
- The REST endpoint signature gains an optional `channelId` query parameter (repeatable). Missing means "no filter" — backward compatible.
- One unrelated build-output drift on `server/setup/conf/mirth.properties` (regenerated keystore passwords on every build) is excluded from the PR by `git update-index --skip-worktree`. Worth tracking separately whether that file should be untracked or templated.

## Out of scope (future PRs)

- Per-channel-buffer cleanup on channel deletion (matches the existing `DefaultConnectionLogController` precedent, which also doesn't clean up).
- Adding unit tests for `DefaultServerLogController` merge/dedup/lastLogId logic.
