### PR TITLE
IRT-1119: fix(donkey): self-heal SourceQueue size when buffer is empty

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/server/queue/SourceQueue.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/queue/SourceQueue.java
@@ -54,6 +54,17 @@ public class SourceQueue extends ConnectorMessageQueue {
             if (connectorMessage == null) {
                 fillBuffer();
                 connectorMessage = pollFirstValue();
+
+                /*
+                 * The buffer is still empty even though size claims there are queued messages.
+                 * The in-memory count has drifted from the database (e.g. an invalidate raced an
+                 * in-flight message), so re-sync it. Otherwise the dashboard shows a phantom
+                 * queued count and this thread hot-spins, querying the database on every poll.
+                 */
+                if (connectorMessage == null && size > 0) {
+                    updateSize();
+                    eventDispatcher.dispatchEvent(new MessageEvent(channelId, metaDataId, MessageEventType.QUEUED, (long) size(), true));
+                }
             }
 
             /*

--- a/donkey/src/test/java/com/mirth/connect/donkey/server/queue/SourceQueueTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/server/queue/SourceQueueTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.donkey.server.queue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.mirth.connect.donkey.model.message.ConnectorMessage;
+import com.mirth.connect.donkey.server.event.EventDispatcher;
+
+/**
+ * Regression tests for IRT-1119: SourceQueue's in-memory size can drift above the true database
+ * count when an invalidate races an in-flight message (poll -> process -> finish). SourceQueue has
+ * no invalidation lock (unlike DestinationQueue), so poll() self-heals by re-syncing the size from
+ * the database whenever the size claims messages exist but the database returns an empty buffer.
+ */
+public class SourceQueueTest {
+
+    private static final String CHANNEL_ID = "sourcequeuetest";
+
+    private SourceQueue queue;
+    private ConnectorMessageQueueDataSource dataSource;
+
+    @Before
+    public void setup() {
+        dataSource = mock(ConnectorMessageQueueDataSource.class);
+        when(dataSource.getChannelId()).thenReturn(CHANNEL_ID);
+        when(dataSource.getMetaDataId()).thenReturn(0);
+
+        queue = new SourceQueue();
+        // The real dispatcher comes from Donkey.getInstance(), which isn't started in unit tests
+        queue.eventDispatcher = mock(EventDispatcher.class);
+        queue.setDataSource(dataSource);
+    }
+
+    private ConnectorMessage message(long messageId) {
+        ConnectorMessage connectorMessage = new ConnectorMessage();
+        connectorMessage.setChannelId(CHANNEL_ID);
+        connectorMessage.setMessageId(messageId);
+        connectorMessage.setMetaDataId(0);
+        return connectorMessage;
+    }
+
+    private Map<Long, ConnectorMessage> buffer(ConnectorMessage... messages) {
+        Map<Long, ConnectorMessage> map = new LinkedHashMap<Long, ConnectorMessage>();
+        for (ConnectorMessage connectorMessage : messages) {
+            map.put(connectorMessage.getMessageId(), connectorMessage);
+        }
+        return map;
+    }
+
+    @Test
+    public void pollShouldHealPhantomSizeWhenDatabaseIsEmpty() {
+        // Seed the drift: the queue believes one message is queued
+        when(dataSource.getSize()).thenReturn(1);
+        queue.updateSize();
+        assertEquals(1, queue.size());
+
+        // But the database actually has nothing queued
+        when(dataSource.getSize()).thenReturn(0);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer());
+
+        assertNull(queue.poll());
+
+        // Without the self-heal the size stays at 1 forever and the queue thread hot-spins
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void invalidateDuringInFlightMessageShouldHealOnNextPoll() {
+        ConnectorMessage inFlight = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(inFlight));
+
+        // The source queue thread checks out the message and starts processing it
+        assertNotNull(queue.poll());
+        assertEquals(0, queue.size());
+
+        // Messages are removed mid-flight: Channel.invalidateQueues() invalidates with no lock,
+        // and the size re-read still counts the in-flight message (still RECEIVED in the database)
+        queue.invalidate(true, false);
+        assertEquals(1, queue.size());
+
+        // The in-flight message commits and finishes; the phantom count is now permanent
+        queue.finish(inFlight);
+        when(dataSource.getSize()).thenReturn(0);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer());
+
+        assertNull(queue.poll());
+        assertEquals(0, queue.size());
+    }
+
+    @Test
+    public void pollShouldNotResyncWhenDatabaseHasMessages() {
+        ConnectorMessage first = message(1);
+        ConnectorMessage second = message(2);
+        when(dataSource.getSize()).thenReturn(2);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(first, second));
+
+        assertEquals(1, queue.poll().getMessageId());
+        queue.finish(first);
+        assertEquals(2, queue.poll().getMessageId());
+        queue.finish(second);
+        assertEquals(0, queue.size());
+
+        // Healthy operation reads the size from the database exactly once (the initial updateSize)
+        verify(dataSource).getSize();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the source-queue "phantom stuck" state (IRT-1119, child of IRT-1116): when `Channel.invalidateQueues()` races an in-flight source-queue message (polled but not yet committed), the queue's in-memory `size` ends up permanently higher than the true database count. The channel then shows a stuck QUEUED count on the dashboard, and the source-queue thread hot-spins — `waitTimeout()` never waits because `size > 0`, so every poll runs a `fillBuffer()` database query in a tight ~0ms loop until a redeploy or a new message clears it.

Unlike `DestinationQueue`, `SourceQueue` has no invalidation lock guarding the window between a message's status commit and its release from the queue, so the invalidate's size re-read can land inside that window and re-count the in-flight message.

## Fix

Self-heal in `SourceQueue.poll()`: if `size > 0` but `fillBuffer()` comes back empty, re-sync `size` from the database and dispatch a QUEUED event so the dashboard count corrects immediately.

This condition is unreachable in a healthy queue — any checked-out in-flight message is still `RECEIVED` in the database and would appear in the buffer — so the heal only runs when the count has already drifted. If the heal itself races another in-flight commit, the next empty poll heals again; the state converges instead of wedging. Zero change to the happy path; cost is one COUNT query per poll only while drifted.

This is candidate fix 1 of 3 from IRT-1119. Fix 3 (porting `DestinationQueue`'s invalidation read/write lock — the root-cause fix) is deferred to a later release under IRT-1116 since it requires holding a lock across the status-commit window in `Channel.process()` and needs soak time; this self-heal remains the safety net underneath it.

## Tests

New `SourceQueueTest` (donkey, Mockito-based, no database required):
- `pollShouldHealPhantomSizeWhenDatabaseIsEmpty` — seeds the drift state directly; fails without the fix (size stays wedged at 1).
- `invalidateDuringInFlightMessageShouldHealOnNextPoll` — replays the actual race (poll → invalidate → finish); fails without the fix.
- `pollShouldNotResyncWhenDatabaseHasMessages` — proves the heal never fires during healthy operation (exactly one `getSize()` call).

Verified both directions: all 3 pass with the fix; the two regression tests fail without it. Existing `com.mirth.connect.donkey.test.QueueTests` suite (full-stack, embedded Derby, includes `testSourceQueueOrderSync` which drives 2000+ messages through the source queue) passes. Full server build succeeds.
