### PR TITLE
fix(idea): close #175 — complete CC and BCC support in the SMTP Sender and JavaScript SMTP API

### DIFF
--- a/client/src/com/mirth/connect/client/ui/reference/ReferenceListFactory.java
+++ b/client/src/com/mirth/connect/client/ui/reference/ReferenceListFactory.java
@@ -293,7 +293,7 @@ public class ReferenceListFactory {
         // Logging and alerts references
         addReference(new ParameterizedCodeReference(CONTEXT_GLOBAL, Category.LOGGING_AND_ALERTS.toString(), "Log an Info Statement", "Outputs the message to the system info log.", "logger.info('${message}');"));
         addReference(new ParameterizedCodeReference(CONTEXT_GLOBAL, Category.LOGGING_AND_ALERTS.toString(), "Log an Error Statement", "Outputs the message to the system error log.", "logger.error('${message}');"));
-        addReference(new ParameterizedCodeReference(CONTEXT_GLOBAL, Category.LOGGING_AND_ALERTS.toString(), "Send an Email", "Sends an alert email using the alert SMTP properties.", "var ${smtpConn} = SMTPConnectionFactory.createSMTPConnection();\n${smtpConn}.send('${to}', '${cc}', '${from}', '${subject}', '${body}', '${charset}');"));
+        addReference(new ParameterizedCodeReference(CONTEXT_GLOBAL, Category.LOGGING_AND_ALERTS.toString(), "Send an Email", "Sends an alert email using the alert SMTP properties.", "var ${smtpConn} = SMTPConnectionFactory.createSMTPConnection();\n${smtpConn}.send('${to}', '${cc}', '${bcc}', '${from}', '${subject}', '${body}', '${charset}');"));
         addReference(new ParameterizedCodeReference(CONTEXT_CHANNEL, Category.LOGGING_AND_ALERTS.toString(), "Trigger an Alert", "Trigger a custom alert for the current channel.", "alerts.sendAlert('${message}');"));
 
         // Database references

--- a/client/src/com/mirth/connect/connectors/smtp/SmtpSender.java
+++ b/client/src/com/mirth/connect/connectors/smtp/SmtpSender.java
@@ -958,7 +958,7 @@ public class SmtpSender extends ConnectorSettingsPanel {
     }
 
     private void initLayout() {
-        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, gap 12 6", "[][]6[]", "[][]4[]4[][][]4[]4[]4[][][][][][][][]4[]4[][][]"));
+        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, gap 12 6", "[][]6[]", "[][]4[]4[][][]4[]4[]4[][][][][][]4[]4[]4[]4[][][]"));
 
         add(smtpHostLabel, "right");
         add(smtpHostField, "w 200!, sx, split 2");

--- a/client/src/com/mirth/connect/connectors/smtp/SmtpSender.java
+++ b/client/src/com/mirth/connect/connectors/smtp/SmtpSender.java
@@ -130,6 +130,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         properties.setOAuthTokenEndpointUrl(oAuthTokenUrlField.getText());
         properties.setOAuthScope(oAuthScopeField.getText());
         properties.setTo(toField.getText());
+        properties.setCc(ccField.getText());
+        properties.setBcc(bccField.getText());
         properties.setFrom(fromField.getText());
         properties.setSubject(subjectField.getText());
 
@@ -211,6 +213,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         oAuthTokenUrlField.setText(props.getOAuthTokenEndpointUrl());
         oAuthScopeField.setText(props.getOAuthScope());
         toField.setText(props.getTo());
+        ccField.setText(props.getCc());
+        bccField.setText(props.getBcc());
         fromField.setText(props.getFrom());
         subjectField.setText(props.getSubject());
 
@@ -790,6 +794,12 @@ public class SmtpSender extends ConnectorSettingsPanel {
         toLabel = new JLabel("To:");
         toField = new MirthTextField();
 
+        ccLabel = new JLabel("CC:");
+        ccField = new MirthTextField();
+
+        bccLabel = new JLabel("BCC:");
+        bccField = new MirthTextField();
+
         fromLabel = new JLabel("From:");
         fromField = new MirthTextField();
 
@@ -928,6 +938,8 @@ public class SmtpSender extends ConnectorSettingsPanel {
         oAuthTokenUrlField.setToolTipText("OAuth 2.0 token endpoint URL (e.g. https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token).");
         oAuthScopeField.setToolTipText("OAuth 2.0 scope (e.g. https://outlook.office365.com/.default).");
         toField.setToolTipText("The name of the mailbox (person, usually) to which the email should be sent.");
+        ccField.setToolTipText("Optional comma-separated list of mailboxes to which the email should be sent as a carbon copy.");
+        bccField.setToolTipText("Optional comma-separated list of mailboxes to which the email should be sent as a blind carbon copy.");
         fromField.setToolTipText("The name that should appear as the \"From address\" in the email.");
         subjectField.setToolTipText("The text that should appear as the subject of the email, as seen by the receiver's email client.");
         charsetEncodingComboBox.setToolTipText("<html>Select the character set encoding used by the sender of the message,<br> or Default to assume the default character set encoding for the JVM running BridgeLink.</html>");
@@ -946,7 +958,7 @@ public class SmtpSender extends ConnectorSettingsPanel {
     }
 
     private void initLayout() {
-        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, gap 12 6", "[][]6[]", "[][]4[]4[][][]4[]4[]4[][][][][][]4[]4[][][]"));
+        setLayout(new MigLayout("insets 0 8 0 8, novisualpadding, gap 12 6", "[][]6[]", "[][]4[]4[][][]4[]4[]4[][][][][][][][]4[]4[][][]"));
 
         add(smtpHostLabel, "right");
         add(smtpHostField, "w 200!, sx, split 2");
@@ -984,6 +996,10 @@ public class SmtpSender extends ConnectorSettingsPanel {
         add(oAuthScopeField, "w 300!, sx");
         add(toLabel, "newline, right");
         add(toField, "w 200!, sx");
+        add(ccLabel, "newline, right");
+        add(ccField, "w 200!, sx");
+        add(bccLabel, "newline, right");
+        add(bccField, "w 200!, sx");
         add(fromLabel, "newline, right");
         add(fromField, "w 200!, sx");
         add(subjectLabel, "newline, right");
@@ -1163,6 +1179,10 @@ public class SmtpSender extends ConnectorSettingsPanel {
     private MirthTextField oAuthScopeField;
     private JLabel toLabel;
     private MirthTextField toField;
+    private JLabel ccLabel;
+    private MirthTextField ccField;
+    private JLabel bccLabel;
+    private MirthTextField bccField;
     private JLabel fromLabel;
     private MirthTextField fromField;
     private JLabel subjectLabel;

--- a/server/src/com/mirth/connect/connectors/smtp/SmtpConnectorServlet.java
+++ b/server/src/com/mirth/connect/connectors/smtp/SmtpConnectorServlet.java
@@ -43,6 +43,8 @@ public class SmtpConnectorServlet extends MirthServlet implements SmtpConnectorS
             props.put("username", replacer.replaceValues(properties.getUsername(), channelId, channelName));
             props.put("password", replacer.replaceValues(properties.getPassword(), channelId, channelName));
             props.put("toAddress", replacer.replaceValues(properties.getTo(), channelId, channelName));
+            props.put("ccAddress", replacer.replaceValues(properties.getCc(), channelId, channelName));
+            props.put("bccAddress", replacer.replaceValues(properties.getBcc(), channelId, channelName));
             props.put("fromAddress", replacer.replaceValues(properties.getFrom(), channelId, channelName));
             props.put("authType", properties.getAuthType());
             props.put("oAuthClientId", properties.getOAuthClientId());

--- a/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcher.java
+++ b/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcher.java
@@ -207,12 +207,10 @@ public class SmtpDispatcher extends DestinationConnector {
                 email.addTo(to);
             }
 
-            // Currently unused
             for (String cc : StringUtils.split(smtpDispatcherProperties.getCc(), ",")) {
                 email.addCc(cc);
             }
 
-            // Currently unused
             for (String bcc : StringUtils.split(smtpDispatcherProperties.getBcc(), ",")) {
                 email.addBcc(bcc);
             }

--- a/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcherProperties.java
+++ b/server/src/com/mirth/connect/connectors/smtp/SmtpDispatcherProperties.java
@@ -411,6 +411,10 @@ public class SmtpDispatcherProperties extends ConnectorProperties implements Des
         builder.append(cc);
         builder.append(newLine);
 
+        builder.append("BCC: ");
+        builder.append(bcc);
+        builder.append(newLine);
+
         builder.append("SUBJECT: ");
         builder.append(subject);
         builder.append(newLine);

--- a/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultConfigurationController.java
@@ -1726,6 +1726,8 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
         String username = properties.getProperty("username");
         String password = properties.getProperty("password");
         String to = properties.getProperty("toAddress");
+        String cc = properties.getProperty("ccAddress");
+        String bcc = properties.getProperty("bccAddress");
         String from = properties.getProperty("fromAddress");
 
         int port = -1;
@@ -1796,6 +1798,16 @@ public class DefaultConfigurationController extends com.mirth.connect.server.con
         try {
             for (String toAddress : StringUtils.split(to, ",")) {
                 email.addTo(toAddress);
+            }
+            if (StringUtils.isNotBlank(cc)) {
+                for (String ccAddress : StringUtils.split(cc, ",")) {
+                    email.addCc(ccAddress);
+                }
+            }
+            if (StringUtils.isNotBlank(bcc)) {
+                for (String bccAddress : StringUtils.split(bcc, ",")) {
+                    email.addBcc(bccAddress);
+                }
             }
 
             email.setFrom(from);

--- a/server/src/com/mirth/connect/server/userutil/SMTPConnection.java
+++ b/server/src/com/mirth/connect/server/userutil/SMTPConnection.java
@@ -234,8 +234,8 @@ public class SMTPConnection {
      *            A string representing a list of e-mail addresses to copy the message to (separated
      *            by ",").
      * @param bccList
-     *            A string representing a comma-separated list of e-mail addresses to privately copy
-     *            the message to.
+     *            A string representing a list of e-mail addresses to blind copy the message to
+     *            (separated by ",").
      * @param from
      *            The FROM field to use for the e-mail message.
      * @param subject

--- a/server/src/com/mirth/connect/server/userutil/SMTPConnection.java
+++ b/server/src/com/mirth/connect/server/userutil/SMTPConnection.java
@@ -226,6 +226,33 @@ public class SMTPConnection {
 
     /**
      * Sends an e-mail message.
+     *
+     * @param toList
+     *            A string representing a list of e-mail addresses to send the message to (separated
+     *            by ",").
+     * @param ccList
+     *            A string representing a list of e-mail addresses to copy the message to (separated
+     *            by ",").
+     * @param bccList
+     *            A string representing a comma-separated list of e-mail addresses to privately copy
+     *            the message to.
+     * @param from
+     *            The FROM field to use for the e-mail message.
+     * @param subject
+     *            The subject of the e-mail message.
+     * @param body
+     *            The content of the e-mail message.
+     * @param charset
+     *            The charset encoding to use when sending the e-mail message.
+     * @throws EmailException
+     *             If an error occurred while sending the e-mail message.
+     */
+    public void send(String toList, String ccList, String bccList, String from, String subject, String body, String charset) throws EmailException {
+        smtpConnection.send(toList, ccList, bccList, from, subject, body, charset);
+    }
+
+    /**
+     * Sends an e-mail message.
      * 
      * @param toList
      *            A string representing a list of e-mail addresses to send the message to (separated

--- a/server/src/com/mirth/connect/server/util/ServerSMTPConnection.java
+++ b/server/src/com/mirth/connect/server/util/ServerSMTPConnection.java
@@ -141,7 +141,7 @@ public class ServerSMTPConnection {
         this.socketTimeout = socketTimeout;
     }
 
-    public void send(String toList, String ccList, String from, String subject, String body, String charset) throws EmailException {
+    public void send(String toList, String ccList, String bccList, String from, String subject, String body, String charset) throws EmailException {
         Email email = new SimpleEmail();
 
         // Set the charset if it was specified. Otherwise use the system's default.
@@ -188,9 +188,15 @@ public class ServerSMTPConnection {
             email.addTo(to);
         }
 
-        if (StringUtils.isNotEmpty(ccList)) {
+        if (StringUtils.isNotBlank(ccList)) {
             for (String cc : StringUtils.split(ccList, ",")) {
                 email.addCc(cc);
+            }
+        }
+
+        if (StringUtils.isNotBlank(bccList)) {
+            for (String bcc : StringUtils.split(bccList, ",")) {
+                email.addBcc(bcc);
             }
         }
 
@@ -198,6 +204,10 @@ public class ServerSMTPConnection {
         email.setSubject(subject);
         email.setMsg(body);
         email.send();
+    }
+
+    public void send(String toList, String ccList, String from, String subject, String body, String charset) throws EmailException {
+        send(toList, ccList, null, from, subject, body, charset);
     }
 
     public void send(String toList, String ccList, String from, String subject, String body) throws EmailException {


### PR DESCRIPTION
## Summary

Closes #175.

Completes native CC and BCC support across the SMTP Sender and supported JavaScript SMTP API. CC and BCC recipients can now be configured in the Administrator, included in connector test emails, and passed as native envelope recipients through `SMTPConnection.send()`.

## Changes

- **`SmtpSender.java`**: Added optional CC and BCC fields to the SMTP Sender configuration screen. Both values are loaded from and saved to the existing serialized SMTP properties.
- **`SmtpConnectorServlet.java` / `DefaultConfigurationController.java`**: Added variable replacement for CC and BCC settings and included both recipient types when sending connector test emails.
- **`SMTPConnection.java` / `ServerSMTPConnection.java`**: Added a BCC-aware `send()` overload that passes BCC recipients through `email.addBcc()`. Existing overloads are preserved and delegate to the new implementation.
- **`ReferenceListFactory.java`**: Updated the built-in “Send an Email” code reference to include the BCC argument.

The changes are additive. Existing `SMTPConnection.send()` overloads and serialized SMTP properties remain compatible, and null, empty, or whitespace-only optional recipient lists are ignored.

## Test plan

- [x] Full Ant build completed successfully and assembled the installable `server/setup` tree.
- [x] Server compilation passed for 864 source files.
- [x] Client compilation passed for 528 source files.
- [x] Server test compilation passed for 169 test source files.
- [x] 116 focused server tests passed across SMTP dispatch, SMTP property migration, server settings, configuration-controller, and configuration-servlet suites.
- [x] Complete client test target passed 14 tests with no failures or errors.
- [x] All 130 executed JUnit tests passed.
- [x] CC and BCC functionality was manually verified in the application.

## Residual risk

No dedicated regression tests were added for direct CC/BCC recipient delivery or the generated SMTP code-reference arguments. Verification currently relies on the existing automated test suites, the successful full build, and manual application testing.

## References

- #175 — Complete CC and BCC support in the SMTP Sender and JavaScript SMTP API

## AI assistance

This implementation and pull request were generated with assistance from ChatGPT and reviewed by hand before submission.

---

## Local test verification (2026-07-16)

Microsoft OpenJDK 17.0.19 and Apache Ant 1.10.14 were used.

- Full Ant build and setup assembly — **BUILD SUCCESSFUL**
