### PR TITLE
fix(IRT-1658): Edit User NPE on non-English JVM locales

### DIFF
--- a/client/src/com/mirth/connect/client/ui/UserEditPanel.java
+++ b/client/src/com/mirth/connect/client/ui/UserEditPanel.java
@@ -82,7 +82,9 @@ public class UserEditPanel extends javax.swing.JPanel {
     private UserDialogInterface dialog;
     private Frame parent;
     private final String DEFAULT_OPTION = "--Select an option--";
-    Map<String, String> countryMap = new HashMap<String, String>(); 
+    private static final String DEFAULT_COUNTRY_CODE = "US";
+    Map<String, String> countryMap = new HashMap<String, String>();
+    private Map<String, String> countryCodeByName = new HashMap<String, String>();
     private List<String> countryNames;
 
     public UserEditPanel() {
@@ -94,22 +96,63 @@ public class UserEditPanel extends javax.swing.JPanel {
 
     }
     
-    private void initializeCountryCodes() {
+    /**
+     * Builds the country code to country name map. The display names are pinned to
+     * Locale.ENGLISH rather than the JVM default locale so that the names shown in the dropdown,
+     * and therefore the value persisted on the user, are the same on every machine.
+     *
+     * @return A map of ISO country code to English country name
+     */
+    static Map<String, String> buildCountryMap() {
     	PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
     	Set<String> countryCodeSet = phoneUtil.getSupportedRegions();
-    	
-    	// get country names for pull down and sort in alphabetical order
+    	Map<String, String> map = new HashMap<String, String>();
+
         for (String item : countryCodeSet) {
             Locale obj = new Locale("", item);
-            String countryName = obj.getDisplayCountry();
-            countryMap.put(item, countryName);
+            map.put(item, obj.getDisplayCountry(Locale.ENGLISH));
         }
+        return map;
+    }
+
+    private void initializeCountryCodes() {
+    	countryMap = buildCountryMap();
+
+    	// reverse lookup so the selected country name can be resolved back to its code
+    	countryCodeByName = new HashMap<String, String>();
+    	for (Map.Entry<String, String> entry : countryMap.entrySet()) {
+    		countryCodeByName.put(entry.getValue(), entry.getKey());
+    	}
+
+    	// get country names for pull down and sort in alphabetical order
     	countryNames = countryMap.values().stream().collect(Collectors.toCollection(ArrayList :: new));
     	java.util.Collections.sort(countryNames);
     }
-    
+
     protected List<String> getCountryNames() {
     	return countryNames;
+    }
+
+    /**
+     * @return The ISO country code for the currently selected country, or null if the selection is
+     *         not a recognized country
+     */
+    String getSelectedCountryCode() {
+    	Object selectedCountry = country.getSelectedItem();
+    	return selectedCountry == null ? null : countryCodeByName.get(selectedCountry.toString());
+    }
+
+    /**
+     * Resolves a stored country value to an entry in the country dropdown. Accepts an English
+     * country name or an ISO country code.
+     *
+     * @return The matching country name, or null if the value is not recognized
+     */
+    private String resolveCountryName(String storedCountry) {
+    	if (countryCodeByName.containsKey(storedCountry)) {
+    		return storedCountry;
+    	}
+    	return countryMap.get(storedCountry.toUpperCase(Locale.ENGLISH));
     }
 
     public void setUser(UserDialogInterface dialog, User user) {
@@ -129,7 +172,12 @@ public class UserEditPanel extends javax.swing.JPanel {
             industry.setSelectedItem(user.getIndustry());
         }
         if (!StringUtils.isBlank(user.getCountry())) {
-            country.setSelectedItem(user.getCountry());
+            // an unrecognized value (e.g. a country name saved by a client running in another
+            // locale) is ignored so that the dropdown keeps its valid default selection
+            String countryName = resolveCountryName(user.getCountry());
+            if (countryName != null) {
+                country.setSelectedItem(countryName);
+            }
         }
         if (!StringUtils.isBlank(user.getStateTerritory())) {
             stateTerritory.setSelectedItem(user.getStateTerritory());
@@ -251,10 +299,11 @@ public class UserEditPanel extends javax.swing.JPanel {
         }
 
         if (StringUtils.isNotBlank(phone.getText())) {
-        	if (country.getSelectedItem().equals(DEFAULT_OPTION)) {
+        	String countryCode = getSelectedCountryCode();
+        	if (country.getSelectedItem().equals(DEFAULT_OPTION) || countryCode == null) {
         		return "Country field is required to validate phone number.";
         	} else {
-        		if (!validatePhoneNumber(phone.getText(), getKeyFromValue(countryMap, country.getSelectedItem()).toString())) {
+        		if (!validatePhoneNumber(phone.getText(), countryCode)) {
             		return "The phone number is invalid for the given Country and/or State/Territory.";
         		}
         	}
@@ -392,7 +441,10 @@ public class UserEditPanel extends javax.swing.JPanel {
         for (String item : getCountryNames()) {
             country.addItem(item);
         }        
-        country.getModel().setSelectedItem("United States");
+        String defaultCountryName = countryMap.get(DEFAULT_COUNTRY_CODE);
+        if (defaultCountryName != null) {
+            country.getModel().setSelectedItem(defaultCountryName);
+        }
         country.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 countryActionPerformed(evt);
@@ -541,19 +593,25 @@ public class UserEditPanel extends javax.swing.JPanel {
 
     private void phoneKeyReleased(KeyEvent evt) {
     	// this commented code will add the country code in front of the phone number - like +1 for the US
-    	phone.setText(formatPhoneNumber(phone.getText(), getKeyFromValue(countryMap, country.getSelectedItem()).toString()));
+    	String countryCode = getSelectedCountryCode();
+    	if (countryCode != null) {
+    		phone.setText(formatPhoneNumber(phone.getText(), countryCode));
+    	}
         checkAndTriggerFinishButton(evt);
     }
 
     private void countryActionPerformed(ActionEvent evt) {
         if (dialog != null) {
-        	if (country.getSelectedItem() == "United States") {
+        	String countryCode = getSelectedCountryCode();
+        	if (DEFAULT_COUNTRY_CODE.equals(countryCode)) {
         		stateTerritory.setEnabled(true);
         	} else {
                 stateTerritory.getModel().setSelectedItem(DEFAULT_OPTION);
         		stateTerritory.setEnabled(false);
         	}
-        	phone.setText(formatPhoneNumber(phone.getText(), getKeyFromValue(countryMap, country.getSelectedItem()).toString()));
+        	if (countryCode != null) {
+        		phone.setText(formatPhoneNumber(phone.getText(), countryCode));
+        	}
             checkIfAbleToFinish();
         }
     }

--- a/client/test/com/mirth/connect/client/ui/UserEditPanelTest.java
+++ b/client/test/com/mirth/connect/client/ui/UserEditPanelTest.java
@@ -1,10 +1,142 @@
 package com.mirth.connect.client.ui;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.awt.GraphicsEnvironment;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.mirth.connect.model.User;
 
 public class UserEditPanelTest {
+
+	private static final List<Locale> NON_ENGLISH_LOCALES = Arrays.asList(Locale.GERMANY, Locale.JAPAN, Locale.FRANCE);
+
+	private static final UserDialogInterface STUB_DIALOG = new UserDialogInterface() {
+		@Override
+		public void setFinishButtonEnabled(boolean enabled) {}
+
+		@Override
+		public void triggerFinishButton() {}
+	};
+
+	/**
+	 * The panel's text fields are MirthTextFields, which dereference PlatformUI.MIRTH_FRAME as soon
+	 * as their text is set.
+	 */
+	@BeforeClass
+	public static void setUpFrame() {
+		if (!GraphicsEnvironment.isHeadless()) {
+			PlatformUI.MIRTH_FRAME = Mockito.mock(Frame.class);
+		}
+	}
+
+	@AfterClass
+	public static void tearDownFrame() {
+		PlatformUI.MIRTH_FRAME = null;
+	}
+
+	/**
+	 * The country names are pinned to English so the value persisted on the user does not depend on
+	 * the locale of the machine running the Administrator.
+	 */
+	@Test
+	public void testCountryNamesArePinnedToEnglish() {
+		Locale originalLocale = Locale.getDefault();
+		try {
+			for (Locale locale : NON_ENGLISH_LOCALES) {
+				Locale.setDefault(locale);
+				assertEquals("United States", UserEditPanel.buildCountryMap().get("US"));
+			}
+		} finally {
+			Locale.setDefault(originalLocale);
+		}
+	}
+
+	/**
+	 * Duplicate display names would put duplicate entries in the dropdown and make the reverse
+	 * lookup from country name to country code ambiguous.
+	 */
+	@Test
+	public void testCountryDisplayNamesAreUnique() {
+		Map<String, String> countryMap = UserEditPanel.buildCountryMap();
+		assertEquals(countryMap.size(), new HashSet<String>(countryMap.values()).size());
+	}
+
+	/**
+	 * IRT-1658: editing a user threw a NullPointerException before the dialog opened on any machine
+	 * whose default locale was not English.
+	 */
+	@Test
+	public void testEditUserUnderNonEnglishLocale() {
+		Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+		Locale originalLocale = Locale.getDefault();
+		try {
+			for (Locale locale : NON_ENGLISH_LOCALES) {
+				Locale.setDefault(locale);
+
+				User user = new User();
+				user.setUsername("testuser");
+				user.setCountry("United States");
+
+				UserEditPanel panel = new UserEditPanel();
+				panel.setUser(STUB_DIALOG, user);
+
+				assertEquals(locale.toString(), "US", panel.getSelectedCountryCode());
+				assertEquals(locale.toString(), "United States", panel.getUser().getCountry());
+			}
+		} finally {
+			Locale.setDefault(originalLocale);
+		}
+	}
+
+	/**
+	 * A country name persisted by a client running in another locale is not in the dropdown. The
+	 * panel keeps its default selection rather than leaving the combo box in an invalid state.
+	 */
+	@Test
+	public void testLegacyLocalizedCountryValueDoesNotCrash() {
+		Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+		User user = new User();
+		user.setUsername("testuser");
+		user.setCountry("Vereinigte Staaten");
+
+		UserEditPanel panel = new UserEditPanel();
+		panel.setUser(STUB_DIALOG, user);
+
+		assertEquals("US", panel.getSelectedCountryCode());
+	}
+
+	/**
+	 * A country stored as an ISO code resolves to the matching dropdown entry.
+	 */
+	@Test
+	public void testCountryCodeResolvesToCountryName() {
+		Assume.assumeFalse(GraphicsEnvironment.isHeadless());
+
+		User user = new User();
+		user.setUsername("testuser");
+		user.setCountry("au");
+
+		UserEditPanel panel = new UserEditPanel();
+		panel.setUser(STUB_DIALOG, user);
+
+		assertEquals("AU", panel.getSelectedCountryCode());
+		assertEquals("Australia", panel.getUser().getCountry());
+	}
 
 	@Test
 	public void testValidatePhoneNumber() {


### PR DESCRIPTION
## Summary

Fixes [IRT-1658](https://innovarhealthcare.atlassian.net/browse/IRT-1658) / #183: on any machine whose JVM default locale is not English, the Administrator's **Edit User** dialog throws an uncaught `NullPointerException` before it can open, leaving every account permanently un-editable with no escape from the UI. **New User** crashes the same way as soon as a phone number is typed.

All changes are in `client/src/com/mirth/connect/client/ui/UserEditPanel.java`.

## Root cause

`initializeCountryCodes()` built the Country dropdown from `Locale.getDisplayCountry()` with **no locale argument**, so the items were named in the JVM default locale, while the initial selection was hardcoded to the English literal `"United States"`.

The selection was applied through `country.getModel().setSelectedItem(...)`, and `DefaultComboBoxModel.setSelectedItem` performs **no validation** (unlike `JComboBox.setSelectedItem`) — so on a non-English locale the model happily held a value that was not one of its own elements. `getUser()` then persisted that literal for every user, because Country is the one combo that never gets the `DEFAULT_OPTION` sentinel added, so its guard could never trip.

On Edit, `setUser()` called `country.setSelectedItem("United States")`. Because that value *equals* the current invalid selection, `JComboBox` short-circuited its reject-invalid branch but still called `fireActionEvent()` on the way out, so `countryActionPerformed()` ran with an invalid selection and `getKeyFromValue(countryMap, ...)` returned null.

Note the subtlety: had the persisted value *not* exactly matched the invalid default, JComboBox would have silently rejected it and no event would have fired — wrong country displayed, no crash. It is the exact match against the invalid default that produces the NPE.

There were **three** unguarded `getKeyFromValue(...).toString()` sites, not one: `validateUser()`, `phoneKeyReleased()`, and `countryActionPerformed()`.

## Changes

- **Pin display names to `Locale.ENGLISH`** in a new static `buildCountryMap()`, so the dropdown — and therefore the value persisted on the user — is identical on every machine. This also makes the stored value locale-independent, fixing the data-integrity problem where a record written on a German box read back as unrecognized on an English one.
- **Derive the default selection from the map** (`countryMap.get("US")`) instead of a hardcoded literal, so it is always a valid model element.
- **Add a null-safe `getSelectedCountryCode()`** backed by a reverse (name to ISO code) map built once at init, and route all three former crash sites through it. `validateUser()` now returns a message rather than validating against the wrong country; the two formatting sites skip formatting rather than crashing.
- **Compare ISO codes instead of `==` on display names.** The old `country.getSelectedItem() == "United States"` was only ever true because the interned literal itself was sitting in the model; once a user picked United States from the dropdown the comparison was false, so **State/Territory was wrongly disabled and reset on English installs too**. That regression is fixed here.
- **Resolve a stored country tolerantly** in `setUser()` — an English display name or an ISO code both resolve; anything unrecognized leaves the valid default selected instead of poisoning the model. The ISO-code branch costs nothing today and makes a future move to persisted codes a read-compatible change.

Persisting ISO codes instead of display names is the cleaner long-term answer, but it would change what `User.country` returns over REST and what the Users table column shows, so it is deliberately out of scope here.

## Not a regression

Blame puts every affected line in upstream Mirth's RS-7551 work (July 2022):

| Commit | Date | Added |
|---|---|---|
| `9a033f72fa` | 2022-07-07 | `getDisplayCountry()` with no locale, and the `==` comparison |
| `c4c2df2f39` | 2022-07-07 | the unguarded phone validate/format sites |
| `3a4c44cc33` | 2022-07-14 | "Change default to United States" — the commit that armed the crash |

First release containing them is **4.1.0** (tagged 2022-07-29); `git tag --contains` lists all 17 tags since, through `v26.6.0`. `git diff v26.6.0 bridgelink_development` on this file is empty — nothing on the Innovar side ever touched it.

## Testing

`client/test/com/mirth/connect/client/ui/UserEditPanelTest.java` gains five tests, run by the build through `client/ant-build.xml`'s `test-run` target. Because JUnit forks once for the whole suite, every locale change is wrapped in try/finally restoring `Locale.getDefault()`. The panel's text fields are `MirthTextField`s, which dereference `PlatformUI.MIRTH_FRAME` as soon as their text is set, so the tests install a `Mockito.mock(Frame.class)` (mockito is already in `server/testlib`; Objenesis skips the constructor, so it costs nothing).

- `testCountryNamesArePinnedToEnglish` — under de_DE, ja_JP, fr_FR the US entry is still `"United States"`
- `testCountryDisplayNamesAreUnique` — guards the reverse map and the dropdown against duplicate entries
- `testEditUserUnderNonEnglishLocale` — the direct regression test: `setUser` with `country = "United States"` under a non-English locale opens and round-trips
- `testLegacyLocalizedCountryValueDoesNotCrash` — a localized name persisted by an affected client no longer crashes
- `testCountryCodeResolvesToCountryName` — a stored ISO code resolves to the right entry

The tests were mutation-checked rather than merely observed to pass. Reverting the locale pin alone fails two of them; compiling the **pristine** pre-fix file from `bridgelink_development` and running the same test reproduces the customer's stack trace frame for frame, including the JDK line numbers `JComboBox.java:619` and `JComboBox.java:1294` from the report.

Manual verification against a local server, under `-Duser.language=de -Duser.country=DE` and `-Duser.language=ja -Duser.country=JP`:

1. Users > select any user > Edit — opens and saves, no NPE in the Java console
2. New User — accepts a phone number without crashing
3. Selecting United States enables State/Territory (also checked on en_US, since that is the English-install regression)
4. A record already carrying `country = "United States"` opens without error

## Workarounds for customers until this ships

Verified against the unmodified v26.6.0 code:

- **Complete:** set `JAVA_TOOL_OPTIONS=-Duser.language=en -Duser.country=US` in the environment, or pass those flags to the Administrator. Confirmed to drive the JVM default locale on this code path.
- **Partial:** clearing the stored country value server-side lets the dialog open, but the combo still shows the invalid default — typing a phone number still crashes until a country is picked from the dropdown, and saving without picking one re-persists the bad value.
