### PR TITLE
fix(IRT-1539): fail the build when unit tests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,10 @@ donkey/donkey-test
 /donkey/donkeydb
 /donkey/donkeytest
 /donkey/derby.log
+
+# Derby test DB / log when ant is invoked from the repo root
+/donkeytest
+/derby.log
 /donkey/nb-build.xml
 /donkey/nbproject
 /donkey/nbbuild

--- a/.gitignore
+++ b/.gitignore
@@ -186,6 +186,8 @@ donkey/donkey-test
 /donkey/build
 /donkey/dist
 /donkey/donkeydb
+/donkey/donkeytest
+/donkey/derby.log
 /donkey/nb-build.xml
 /donkey/nbproject
 /donkey/nbbuild
@@ -348,6 +350,7 @@ donkey/donkey-test
 /server/setup
 /server/bin
 /server/derby.log
+/server/donkeytest
 /server/dist
 /server/.settings
 /server/build

--- a/client/ant-build.xml
+++ b/client/ant-build.xml
@@ -363,7 +363,12 @@
 		<mkdir dir="${code-coverage-reports}" />
 		
 		<jacoco:coverage destfile="${code-coverage-reports}/jacoco.exec" xmlns:jacoco="antlib:org.jacoco.ant" exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader" >
-			<junit haltonfailure="false" fork="true" forkmode="once">
+			<!--
+				haltonfailure stays false on purpose: the run must finish so that the JUnit XML
+				and the JaCoCo coverage data are written even when tests fail. The build is
+				failed by the <fail> at the end of this target instead.
+			-->
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="once">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 				<jvmarg value="--add-opens=java.base/sun.misc=ALL-UNNAMED"/>
@@ -385,8 +390,18 @@
 				</batchtest>
 			</junit>
 		</jacoco:coverage>
+
+		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<fail message="Unit tests failed in client. See ${junit-reports}/ for details.">
+			<condition>
+				<or>
+					<isset property="tests.failed" />
+					<isset property="tests.errored" />
+				</or>
+			</condition>
+		</fail>
 	</target>
-	
+
 	<target name="remove-classes" depends="init">
 		<!-- delete the compiled classes folder -->
 		<delete dir="${classes}" />

--- a/command/build.xml
+++ b/command/build.xml
@@ -97,7 +97,12 @@
 		<mkdir dir="${code-coverage-reports}" />
 		
 		<jacoco:coverage destfile="${code-coverage-reports}/jacoco.exec" xmlns:jacoco="antlib:org.jacoco.ant" exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader" >
-			<junit haltonfailure="false" fork="true" forkmode="once">
+			<!--
+				haltonfailure stays false on purpose: the run must finish so that the JUnit XML
+				and the JaCoCo coverage data are written even when tests fail. The build is
+				failed by the <fail> at the end of this target instead.
+			-->
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="once">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 				<jvmarg value="--add-opens=java.base/sun.misc=ALL-UNNAMED"/>
@@ -119,5 +124,15 @@
 				</batchtest>
 			</junit>
 		</jacoco:coverage>
+
+		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<fail message="Unit tests failed in command. See ${junit-reports}/ for details.">
+			<condition>
+				<or>
+					<isset property="tests.failed" />
+					<isset property="tests.errored" />
+				</or>
+			</condition>
+		</fail>
 	</target>
 </project>

--- a/custom-extensions/dynamic-lookup-gateway/build.xml
+++ b/custom-extensions/dynamic-lookup-gateway/build.xml
@@ -197,7 +197,12 @@
         <jacoco:coverage destfile="code-coverage-reports/jacoco.exec"
                          xmlns:jacoco="antlib:org.jacoco.ant"
                          exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader">
-            <junit haltonfailure="false" fork="true" forkmode="perTest">
+            <!--
+                haltonfailure stays false on purpose: the run must finish so that the JUnit XML,
+                the HTML report and the JaCoCo coverage below are all written even when tests
+                fail. The build is failed by the <fail> at the end of this target instead.
+            -->
+            <junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="perTest">
                 <jvmarg value="--add-opens=java.base/java.util=ALL-UNNAMED"/>
                 <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
                 <classpath>
@@ -221,6 +226,16 @@
             </fileset>
             <report format="frames" todir="junit-html"/>
         </junitreport>
+
+        <!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+        <fail message="Unit tests failed in dynamic-lookup-gateway. See junit-reports/ for details.">
+            <condition>
+                <or>
+                    <isset property="tests.failed"/>
+                    <isset property="tests.errored"/>
+                </or>
+            </condition>
+        </fail>
     </target>
 
     <target name="build" depends="clean, jar">

--- a/custom-extensions/message-trends/build.xml
+++ b/custom-extensions/message-trends/build.xml
@@ -187,7 +187,12 @@
         <jacoco:coverage destfile="code-coverage-reports/jacoco.exec"
                          xmlns:jacoco="antlib:org.jacoco.ant"
                          exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader">
-            <junit haltonfailure="false" fork="true" forkmode="perTest">
+            <!--
+                haltonfailure stays false on purpose: the run must finish so that the JUnit XML,
+                the HTML report and the JaCoCo coverage below are all written even when tests
+                fail. The build is failed by the <fail> at the end of this target instead.
+            -->
+            <junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="perTest">
                 <jvmarg value="--add-opens=java.base/java.util=ALL-UNNAMED"/>
                 <jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
                 <classpath>
@@ -211,6 +216,16 @@
             </fileset>
             <report format="frames" todir="junit-html"/>
         </junitreport>
+
+        <!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+        <fail message="Unit tests failed in message-trends. See junit-reports/ for details.">
+            <condition>
+                <or>
+                    <isset property="tests.failed"/>
+                    <isset property="tests.errored"/>
+                </or>
+            </condition>
+        </fail>
     </target>
 
     <target name="build" depends="clean, jar">

--- a/donkey/build.xml
+++ b/donkey/build.xml
@@ -104,6 +104,13 @@
 	<taskdef uri="antlib:org.jacoco.ant"
 			 resource="org/jacoco/ant/antlib.xml"
 			 classpathref="jacoco.classpath"/>
+
+	<!-- Ant-Contrib provides <trycatch>, used to guarantee docker cleanup when tests fail. -->
+	<taskdef resource="net/sf/antcontrib/antlib.xml">
+		<classpath>
+			<fileset dir="${server}/lib/ant" includes="ant-contrib*.jar"/>
+		</classpath>
+	</taskdef>
 	
 	<target name="test-run" depends="test-compile" description="Run unit tests and generate code coverage">
 		<property name="junit-reports" value="junit-reports" />
@@ -445,7 +452,7 @@
 				the HTML report and the JaCoCo coverage below are all written even when tests
 				fail. The build is failed by the <fail> at the end of this target instead.
 			-->
-			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="perBatch" dir="${basedir}">
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed.db" errorproperty="tests.errored.db" fork="true" forkmode="perBatch" dir="${basedir}">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 				<jvmarg value="--add-opens=java.base/sun.misc=ALL-UNNAMED"/>
@@ -587,12 +594,17 @@
 		<echo message="Coverage Report: ${db.jacoco-html}/index.html"/>
 		<echo message="========================================"/>
 
-		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<!--
+			Gate the build on the test results. Must stay last so the reports above are written
+			first. Property names differ from test-run's so that running both targets in one
+			invocation (ant -k test-run test-run-postgres-db) cannot make this gate report a
+			failure that belongs to the other target.
+		-->
 		<fail message="Unit tests failed in donkey against ${db.type}. See ${db.junit-reports}/ for details.">
 			<condition>
 				<or>
-					<isset property="tests.failed" />
-					<isset property="tests.errored" />
+					<isset property="tests.failed.db" />
+					<isset property="tests.errored.db" />
 				</or>
 			</condition>
 		</fail>
@@ -604,6 +616,27 @@
 		<antcall target="test-run-db-only">
 			<param name="db.type" value="${db.type}"/>
 		</antcall>
+	</target>
+
+	<!--
+		Runs the tests for one database and cleans up its container afterwards, whether the
+		tests pass or fail. The <fail> at the end of test-run-db-only would otherwise skip
+		cleanup on exactly the runs that need it, leaving a stale container and volume for
+		the next run to reuse. trycatch has no <catch>, so the failure still propagates.
+	-->
+	<target name="test-run-db-with-cleanup" depends="init">
+		<trycatch>
+			<try>
+				<antcall target="test-run-db-only">
+					<param name="db.type" value="${db.type}"/>
+				</antcall>
+			</try>
+			<finally>
+				<antcall target="docker-cleanup-db">
+					<param name="db.type" value="${db.type}"/>
+				</antcall>
+			</finally>
+		</trycatch>
 	</target>
 
 	<target name="test-run-db-isolated" depends="test-compile" description="Run tests against a specific database with automatic cleanup">
@@ -621,13 +654,8 @@
 			<param name="db.type" value="${db.type}"/>
 		</antcall>
 
-		<!-- Run tests -->
-		<antcall target="test-run-db-only">
-			<param name="db.type" value="${db.type}"/>
-		</antcall>
-
-		<!-- Stop and cleanup the database -->
-		<antcall target="docker-cleanup-db">
+		<!-- Run tests, then stop and clean up the database even if they failed -->
+		<antcall target="test-run-db-with-cleanup">
 			<param name="db.type" value="${db.type}"/>
 		</antcall>
 
@@ -652,10 +680,7 @@
 		<antcall target="docker-start-db">
 			<param name="db.type" value="postgres"/>
 		</antcall>
-		<antcall target="test-run-db-only">
-			<param name="db.type" value="postgres"/>
-		</antcall>
-		<antcall target="docker-cleanup-db">
+		<antcall target="test-run-db-with-cleanup">
 			<param name="db.type" value="postgres"/>
 		</antcall>
 	</target>
@@ -666,10 +691,7 @@
 		<antcall target="docker-start-db">
 			<param name="db.type" value="mysql"/>
 		</antcall>
-		<antcall target="test-run-db-only">
-			<param name="db.type" value="mysql"/>
-		</antcall>
-		<antcall target="docker-cleanup-db">
+		<antcall target="test-run-db-with-cleanup">
 			<param name="db.type" value="mysql"/>
 		</antcall>
 	</target>
@@ -680,10 +702,7 @@
 		<antcall target="docker-start-db">
 			<param name="db.type" value="sqlserver"/>
 		</antcall>
-		<antcall target="test-run-db-only">
-			<param name="db.type" value="sqlserver"/>
-		</antcall>
-		<antcall target="docker-cleanup-db">
+		<antcall target="test-run-db-with-cleanup">
 			<param name="db.type" value="sqlserver"/>
 		</antcall>
 	</target>

--- a/donkey/build.xml
+++ b/donkey/build.xml
@@ -119,7 +119,12 @@
 		</exec>
 
 		<jacoco:coverage destfile="${code-coverage-reports}/jacoco.exec" xmlns:jacoco="antlib:org.jacoco.ant" exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader" >
-			<junit haltonfailure="false" fork="true" forkmode="once" dir="${basedir}">
+			<!--
+				haltonfailure stays false on purpose: the run must finish so that the JUnit XML,
+				the HTML report and the JaCoCo coverage below are all written even when tests
+				fail. The build is failed by the <fail> at the end of this target instead.
+			-->
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="once" dir="${basedir}">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 				<jvmarg value="--add-opens=java.base/sun.misc=ALL-UNNAMED"/>
@@ -232,6 +237,16 @@
 
 		<!-- Automatically generate JaCoCo HTML report after tests -->
 		<antcall target="jacoco-report"/>
+
+		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<fail message="Unit tests failed in donkey. See ${junit-reports}/ for details.">
+			<condition>
+				<or>
+					<isset property="tests.failed" />
+					<isset property="tests.errored" />
+				</or>
+			</condition>
+		</fail>
 	</target>
 
 	<target name="jacoco-report" depends="init" description="Generate JaCoCo code coverage reports">
@@ -425,7 +440,12 @@
 		</exec>
 
 		<jacoco:coverage destfile="${db.code-coverage-reports}/jacoco.exec" xmlns:jacoco="antlib:org.jacoco.ant" exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader">
-			<junit haltonfailure="false" fork="true" forkmode="perBatch" dir="${basedir}">
+			<!--
+				haltonfailure stays false on purpose: the run must finish so that the JUnit XML,
+				the HTML report and the JaCoCo coverage below are all written even when tests
+				fail. The build is failed by the <fail> at the end of this target instead.
+			-->
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="perBatch" dir="${basedir}">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 				<jvmarg value="--add-opens=java.base/sun.misc=ALL-UNNAMED"/>
@@ -566,6 +586,16 @@
 		<echo message="JUnit Report: ${db.junit-html}/index.html"/>
 		<echo message="Coverage Report: ${db.jacoco-html}/index.html"/>
 		<echo message="========================================"/>
+
+		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<fail message="Unit tests failed in donkey against ${db.type}. See ${db.junit-reports}/ for details.">
+			<condition>
+				<or>
+					<isset property="tests.failed" />
+					<isset property="tests.errored" />
+				</or>
+			</condition>
+		</fail>
 	</target>
 
 	<target name="test-run-db" depends="test-compile, docker-start-db" description="Run tests against a specific database (auto-starts database)">

--- a/donkey/conf/donkey-testing.properties
+++ b/donkey/conf/donkey-testing.properties
@@ -4,12 +4,15 @@
 database = derby
 
 # examples:
-#	Derby		jdbc:derby:${dir.base}/mirthdb;create=true
+#	Derby		jdbc:derby:mirthdb;create=true
 #	PostgreSQL	jdbc:postgresql://localhost:5432/mirthdb
 # 	MySQL		jdbc:mysql://localhost:3306/mirthdb
 #	Oracle		jdbc:oracle:thin:@localhost:1521:DB
 #	SQLServer	jdbc:jtds:sqlserver://localhost:1433/mirthdb
-database.url = jdbc:derby:${dir.base}/donkeytest;create=true
+# Relative to the working directory of the test JVM. Do not use ${dir.base} here:
+# this file is read verbatim by TestUtils and handed straight to the JDBC driver,
+# with no property substitution, so a placeholder becomes a literal directory name.
+database.url = jdbc:derby:donkeytest;create=true
 
 # if using a custom driver, specify it here
 database.driver = org.apache.derby.jdbc.EmbeddedDriver

--- a/server/build.xml
+++ b/server/build.xml
@@ -1301,7 +1301,12 @@
 		<mkdir dir="${junit-html}" />
 
 		<jacoco:coverage destfile="${code-coverage-reports}/jacoco.exec" xmlns:jacoco="antlib:org.jacoco.ant" exclclassloader="sun.reflect.DelegatingClassLoader:javassist.Loader" >
-			<junit haltonfailure="false" fork="true" forkmode="perTest">
+			<!--
+				haltonfailure stays false on purpose: the run must finish so that the JUnit XML,
+				the HTML report and the JaCoCo coverage below are all written even when tests
+				fail. The build is failed by the <fail> at the end of this target instead.
+			-->
+			<junit haltonfailure="false" printsummary="yes" failureproperty="tests.failed" errorproperty="tests.errored" fork="true" forkmode="perTest">
 				<jvmarg value="-Xms128m" />
 				<jvmarg value="-Xmx2048m" />
 <!--				&lt;!&ndash;Uncomment the following and add additional dashes in front of the arguments to allow Java 9+-->
@@ -1333,6 +1338,13 @@
 				</classpath>
 				<formatter type="xml" />
 				<batchtest todir="${junit-reports}">
+					<!--
+						*Test only, deliberately. The 23 legacy *Tests classes under server/test are
+						quarantined: they require infrastructure this build does not provide (a live
+						PostgreSQL on localhost:5432, ActiveMQ on 61616, /tmp/prunertest, Windows
+						paths such as C:\NCPDP_*.txt). Adding **/*Tests.class here to match donkey's
+						fileset would pull in ~145 tests that cannot pass and would fail every build.
+					-->
 					<fileset dir="${test_classes}">
 						<include name="**/*Test.class" />
 					</fileset>
@@ -1350,6 +1362,16 @@
 
 		<!-- Automatically generate JaCoCo HTML report after tests -->
 		<antcall target="jacoco-report"/>
+
+		<!-- Gate the build on the test results. Must stay last so the reports above are written first. -->
+		<fail message="Unit tests failed in server. See ${junit-reports}/ for details.">
+			<condition>
+				<or>
+					<isset property="tests.failed" />
+					<isset property="tests.errored" />
+				</or>
+			</condition>
+		</fail>
 	</target>
 
 	<target name="jacoco-report" depends="init">

--- a/server/mirth-build.xml
+++ b/server/mirth-build.xml
@@ -133,6 +133,14 @@
 			<fileset dir="${server.setup}/client-lib" />
 		</copy>
 		
+		<antcall target="maybe-test-run" />
+	</target>
+
+	<!--
+		The unit tests now fail the build (see the <fail> at the end of each module's test-run
+		target). Pass -Dskip.tests=true to produce a distribution without running them.
+	-->
+	<target name="maybe-test-run" unless="skip.tests">
 		<antcall target="test-run" />
 	</target>
 

--- a/server/mirth-build.xml
+++ b/server/mirth-build.xml
@@ -133,6 +133,14 @@
 			<fileset dir="${server.setup}/client-lib" />
 		</copy>
 		
+		<!--
+			Ant's unless= tests whether a property is SET, not whether it is true, so guarding
+			maybe-test-run on skip.tests directly would let -Dskip.tests=false silently skip the
+			whole suite. Resolve the value to a boolean first.
+		-->
+		<condition property="skip.tests.enabled">
+			<istrue value="${skip.tests}" />
+		</condition>
 		<antcall target="maybe-test-run" />
 	</target>
 
@@ -140,7 +148,7 @@
 		The unit tests now fail the build (see the <fail> at the end of each module's test-run
 		target). Pass -Dskip.tests=true to produce a distribution without running them.
 	-->
-	<target name="maybe-test-run" unless="skip.tests">
+	<target name="maybe-test-run" unless="skip.tests.enabled">
 		<antcall target="test-run" />
 	</target>
 


### PR DESCRIPTION
## Problem

Every `<junit>` task in the repo was `haltonfailure="false"` with no `failureproperty`, no `errorproperty` and no downstream `<fail>`, so none of the ~2,200 tests that actually run could turn a build red. No task set `printsummary` either, so a failing test was invisible in the console output as well as in the exit code — a broken test still produced `BUILD SUCCESSFUL`.

Two notes on the ticket description, which this PR does not match exactly:

- **Tests were already wired into the default build.** `server/mirth-build.xml:136` has called `test-run` from the `build` target since 2017 (`f4f7713ed`, upstream MIRTH-4120). The wiring was fine; only the gate was missing.
- **Step 3 turned out to be free.** A full run at the branch point was already green, so no quarantine campaign was needed. The suite is 2,207 tests across 218 classes, 0 failures.

The two CI-facing acceptance criteria are deliberately **not** addressed here — the `Build bridgelink` workflow has been `disabled_manually` since 2025-07-16, and re-enabling it is Phase 2, to be done once this merges. Turning CI back on before this gate exists would just produce a green check that proves nothing.

## What changed

`failureproperty`, `errorproperty` and `printsummary` on all seven junit tasks, plus a trailing `<fail>` in each module's `test-run` target:

- `server/build.xml`
- `donkey/build.xml` (both `test-run` and `test-run-db-only`)
- `client/ant-build.xml`
- `command/build.xml`
- `custom-extensions/dynamic-lookup-gateway/build.xml`
- `custom-extensions/message-trends/build.xml`

### Why `haltonfailure` stays false

Every junit task is wrapped in `<jacoco:coverage>` and most are followed by `<junitreport>`. Halting inside the junit task would skip report and coverage generation exactly when those reports are most useful. Running the full batch, writing the reports, then failing gives you both the gate and the diagnostics — confirmed below.

### Why the `<fail>` is per-module

Ant properties flow *down* into sub-builds but never back *up*, so a `failureproperty` set inside a module is invisible to `mirth-build.xml`. Build failures do propagate, so the chain still reaches the top:

```
mirth-build.xml build
  -> antcall maybe-test-run
    -> antcall test-run
      -> ant <module> test-run
        -> fail
```

### Behavior change worth reviewing

Because each module gates itself, **the first failing module stops the remaining ones.** This also affects `donkey`'s `test-run-all-databases`, which antcalls five databases in sequence: a failure in one now aborts the rest of the matrix. Still an improvement — it previously printed `All database tests completed!` even if every database had failed.

### Escape hatch

The `build` target both packages the distribution and runs the tests, so an unrelated broken test would otherwise block packaging entirely. `-Dskip.tests=true` builds without them.

### Also included

- **Documented the `server` fileset.** `server/build.xml` selects only `**/*Test.class`, excluding 23 legacy `*Tests` classes. That exclusion is load-bearing but was undocumented — those tests hardcode `jdbc:postgresql://localhost:5432/mirthdb`, ActiveMQ on `61616`, `/tmp/prunertest` and `C:\NCPDP_*.txt`. Now that the build fails on test failures, "fixing" the inconsistency with donkey's fileset would pull in ~145 tests that cannot pass and would break every build. Added a comment saying so.
- **Removed an undefined `${dir.base}`** from `donkey/conf/donkey-testing.properties`. That file is read verbatim by `TestUtils` and handed straight to the JDBC driver with no property substitution, so Derby was creating directories named literally `${dir.base}`. Plus `.gitignore` entries for the test DB and `derby.log`.

## Verification

| Check | Result |
|---|---|
| Clean full build | exit 0 — 2,207 tests, 218 classes, 0 failures, 28m49s |
| Assertion failure | exit 1, `<fail>` names the module |
| Thrown exception (`errorproperty` path) | exit 1, `Errors: 1` |
| Reports written on a red build | 21 XML files + JUnit HTML + JaCoCo HTML |
| Full `antcall`/`ant` chain propagation | exit 1, trace walks all four legs |
| `-Dskip.tests=true` with a test broken | exit 0, distribution still produced, 2m30s |

Reviewers can reproduce the gate with a one-line `org.junit.Assert.fail(...)` in any test:

```
cd server && ant -f mirth-build.xml
```

## Follow-up

Phase 2 — re-enabling the workflow on pull requests, publishing the JUnit XML as an artifact, and a soak period before making the check required — lands separately once this is on `bridgelink_development`.
