### PR TITLE
ci(IRT-1539): publish test results and harden the build workflow

### DIFF
--- a/.github/workflows/build_bridgelink.yml
+++ b/.github/workflows/build_bridgelink.yml
@@ -1,5 +1,11 @@
 # This workflow will build a Java project with Ant
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-ant
+#
+# The default `build` target runs the unit tests (server/mirth-build.xml calls
+# test-run), and as of IRT-1539 a failing test fails the build. This workflow is
+# therefore the enforcement point: a red test suite is a red pull request.
+#
+# Pass -Dskip.tests=true to build a distribution without running the tests.
 
 name: Build bridgelink
 
@@ -11,9 +17,22 @@ on:
     branches:
       - bridgelink_development
 
+# A full build plus the ~2,200 unit tests takes roughly half an hour, so cancel
+# superseded runs rather than queueing them behind each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    # The build itself is ~5 minutes and the test suite ~30. The ceiling is here to
+    # kill a hung run: without it the job inherits GitHub's 360-minute default, and
+    # this workflow has previously had a run hang rather than fail.
+    timeout-minutes: 90
+
+    env:
+      ANT_OPTS: -Xmx512m
 
     steps:
       - uses: actions/checkout@v4
@@ -25,6 +44,15 @@ jobs:
           java-package: 'jdk+fx'
           distribution: 'zulu'
 
+      # Ant is currently present on the ubuntu-latest image, but nothing pins it
+      # there. Installing it explicitly keeps an image refresh from breaking the
+      # build for reasons that have nothing to do with this repository.
+      - name: Install Ant
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ant
+          ant -version
+
       - name: Build Bridgelink - signed
         if: github.ref == 'refs/heads/bridgelink_development'
         working-directory: server
@@ -34,6 +62,25 @@ jobs:
         if: github.ref != 'refs/heads/bridgelink_development'
         working-directory: server
         run: ant -f mirth-build.xml -DdisableSigning=true
+
+      # if: always() so the reports survive a failing build - that is the run where
+      # they matter. Each module writes its own junit-reports/ directory; they are
+      # collected here rather than from aggregate-reports/ because the aggregation
+      # target runs after all modules and so is skipped when the gate fires.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-test-results
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            donkey/junit-reports/TEST-*.xml
+            server/junit-reports/TEST-*.xml
+            client/junit-reports/TEST-*.xml
+            command/junit-reports/TEST-*.xml
+            custom-extensions/dynamic-lookup-gateway/junit-reports/TEST-*.xml
+            custom-extensions/message-trends/junit-reports/TEST-*.xml
 
       - name: Package distribution
         run: tar czf bridgelink.tar.gz -C server/ setup --transform 's|^setup|bridgelink/|'


### PR DESCRIPTION
Second half of IRT-1539. The Ant gate landed in #189; this makes CI the place it is enforced.

## Context

The `Build bridgelink` workflow has been **`disabled_manually` since 2025-07-16** — switched off seven minutes after a failed run, and dark for 391 days. It has run four times in its life (three failures, one success).

Two things that are easy to get wrong about this:

- **The tests were already wired into CI.** `server/mirth-build.xml` has called `test-run` from the default `build` target since 2017. The trigger config was already correct too — `pull_request` against `bridgelink_development` has been there since the file was written.
- **So nothing here adds test execution.** #189 made a failing test fail the build; this PR makes the results visible and the job survivable. The reason nothing ran was simply that the workflow was off.

**Re-enabling the workflow is a repository setting, not a file change**, so it is not in this diff. It needs `gh workflow enable "Build bridgelink"` or Actions → Build bridgelink → Enable workflow.

## Changes

**Publish the JUnit XML** as a `junit-test-results` artifact with `if: always()`, retained 14 days. This is the ticket's second acceptance criterion.

One deliberate deviation from the original plan here: the reports are collected from each module's `junit-reports/` rather than from `aggregate-reports/`. The aggregation target runs *after* all modules, so the fail-fast gate skips it — aggregating would produce an empty artifact on exactly the red builds you want to inspect. Per-module reports are always written (verified in #189: a failing run still produced all 21 donkey report files plus the HTML and coverage reports).

**Install Ant explicitly.** It is on the `ubuntu-latest` image today, but nothing pins it there and the workflow never installed it. The 33-second failure in the run history is consistent with a missing tool. Twenty seconds of `apt-get` removes a whole class of future breakage that has nothing to do with this repo.

**`timeout-minutes: 90`.** There was no ceiling, so the job inherited GitHub's 360-minute default — and one run in the history hung for the equivalent of thirteen months before dying. Build is ~5 min and the suite ~30 locally; 90 leaves headroom for a slower runner while still catching a hang. Worth tightening once there are real numbers.

**`concurrency` with `cancel-in-progress`,** so a ~35-minute job doesn't queue behind superseded runs of the same ref.

**`ANT_OPTS=-Xmx512m`,** matching the documented local invocation in `CLAUDE.md`.

## What this will cost per run

Roughly 35–45 minutes: ~5 minutes to build, ~30 for 2,207 tests locally, plus runner overhead. The repository is public, so Actions minutes are free.

## Rollout — please leave this check non-required at first

The suite is green locally on macOS but **has never run on headless Linux**. The first run is a discovery run. Recommend leaving the check non-required in branch protection until it has been green across a handful of real PRs, then making it required.

Most likely sources of first-run trouble, in order:

1. **Timing flakes.** ~30 tests use `Thread.sleep`, concentrated in `donkey`'s `QueueTests` (13 sleeps), `TcpDispatcherTest` (15, including a `sleep(3000)`), `DataPrunerJobTest` (Quartz scheduling at `now + 1000ms`), and `TtlUtilsTest` (a 500 ms assertion window). Shared-runner CPU contention is what these are sensitive to.
2. **The historical unknown.** Three of four past runs failed and the logs have expired (HTTP 410), so that cause is unrecoverable and could resurface.
3. **Port 6666**, hardcoded in `TcpReceiverTest` and `TcpDispatcherTest` — low risk, each job gets a fresh VM.
4. **Headless Swing** — low risk. `UserEditPanelTest` guards its frame mock behind `isHeadless()` and the three tests that construct a `UserEditPanel` each carry `Assume.assumeFalse(isHeadless())`. No `xvfb` needed.

`-Dskip.tests=true` is the escape hatch if something needs to ship while a flake is being fixed.

## Deliberately not included

- **A third-party test-reporter action** (`dorny/test-reporter` and similar) would turn failures into inline PR annotations, which is nicer than reading the log. Left out to avoid introducing an unvetted third-party action into a public healthcare repository without a policy discussion. The artifact plus the red X covers the acceptance criterion; the reporter is a easy follow-up if you want it.
- **`-DdisableSigning=true`** in the unsigned build step is read by nothing in the build — the signed and unsigned paths are identical. Left alone rather than quietly changed, but worth knowing before someone debugs a signing problem that does not exist.

## Note on the other 10 open PRs

Enabling the workflow does not retroactively run anything. Existing PRs will get their first run when they are next pushed to or reopened. Several are long-lived (#50, #51, #92) and may well go red — that would be information, not a regression.
