### PR TITLE
fix(donkey): close two overwrite races on source-queued channels (IRT-1655)

### DIFF
--- a/donkey/src/main/java/com/mirth/connect/donkey/server/Constants.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/Constants.java
@@ -58,6 +58,24 @@ public class Constants {
     public static final int DESTINATION_QUEUE_EMPTY_SLEEP_TIME = 200;
 
     /**
+     * The number of milliseconds an overwriting dispatch will wait for an in-flight copy of the
+     * message it is replacing to leave the source queue, before giving up and failing the dispatch.
+     *
+     * <p>
+     * This is a safety valve, not a tuning knob. The wait normally ends as soon as the in-flight
+     * attempt finishes, and a legitimate attempt is bounded by the destination send timeouts. Without
+     * a bound, a message wedged in the source queue error-retry loop would keep an overwriting
+     * dispatch spinning indefinitely while it holds a process lock permit.
+     */
+    public static final int OVERWRITE_QUIESCE_TIMEOUT_MILLIS = 300000;
+
+    /**
+     * The number of milliseconds between checks while an overwriting dispatch waits for an in-flight
+     * copy of the message it is replacing
+     */
+    public static final int OVERWRITE_QUIESCE_POLL_MILLIS = 100;
+
+    /**
      * Thread priority level for the event handler
      */
     public static final int EVENT_HANDLER_THREAD_PRIORITY = 2;

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/channel/Channel.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/channel/Channel.java
@@ -138,6 +138,22 @@ public class Channel implements Runnable {
     private ChannelProcessLock processLock;
     private Lock removeContentLock = new ReentrantLock(true);
 
+    /*
+     * Serializes overwriting dispatches that target the same message id. The quiesce, the delete of the
+     * previous message's rows, the insert of the replacement and the queue addition have to happen as
+     * one unit: synchronizing on sourceQueue covers only the commit and the queue addition, so without
+     * this two dispatch threads could both quiesce the same message, both see it as not checked out, and
+     * then interleave their deletes and inserts. One pass's queued copy is discarded from the buffer
+     * while its row stays RECEIVED and the queue size no longer accounts for it, so nothing ever polls
+     * it again and the message silently never processes (IRT-1655).
+     *
+     * Striped rather than one lock per message id so the memory is bounded, and rather than a single
+     * channel-wide lock so that one message cannot hold up overwrites of unrelated messages. Different
+     * ids that hash to the same stripe are merely serialized, which is harmless.
+     */
+    private static final int OVERWRITE_LOCK_STRIPES = 64;
+    private final Lock[] overwriteLocks = newOverwriteLocks();
+
     private MessageController messageController = MessageController.getInstance();
 
     private Logger logger = LogManager.getLogger(getClass());
@@ -1255,6 +1271,7 @@ public class Channel implements Runnable {
         Thread currentThread = Thread.currentThread();
         String originalThreadName = currentThread.getName();
         boolean lockAcquired = false;
+        Lock overwriteLock = null;
         Long persistedMessageId = null;
 
         try {
@@ -1284,6 +1301,26 @@ public class Channel implements Runnable {
                 lockAcquired = true;
 
                 /*
+                 * Overwriting dispatches that target the same message id have to run one at a time,
+                 * from the quiesce below through to the queue addition, otherwise their deletes and
+                 * inserts interleave. Acquired before obtaining a dao so that a database connection is
+                 * not held open while waiting on another pass.
+                 */
+                if (isOverwrite(rawMessage)) {
+                    Lock lock = getOverwriteLock(rawMessage.getOriginalMessageId());
+                    lock.lockInterruptibly();
+                    // Only recorded once actually held, so the finally below never unlocks what it does not own
+                    overwriteLock = lock;
+                }
+
+                /*
+                 * If this message overwrites a previous one, quiesce the queues before any of the
+                 * previous message's rows are deleted. This is done before obtaining a dao so that a
+                 * database connection is not held open for the duration of the wait.
+                 */
+                markDeletedQueuedMessages(rawMessage);
+
+                /*
                  * TRANSACTION: Create Raw Message - create a source connector message from the raw
                  * message and set the status as RECEIVED - store attachments
                  */
@@ -1297,8 +1334,6 @@ public class Channel implements Runnable {
                     persistedMessageId = sourceMessage.getMessageId();
                     dao.close();
 
-                    markDeletedQueuedMessages(rawMessage, persistedMessageId);
-
                     processedMessage = process(sourceMessage, false);
                 } else {
                     // Block other threads from adding to the source queue until both the current commit and queue addition finishes
@@ -1308,9 +1343,18 @@ public class Channel implements Runnable {
                         persistedMessageId = sourceMessage.getMessageId();
                         dao.close();
                         queue(sourceMessage);
-                    }
 
-                    markDeletedQueuedMessages(rawMessage, persistedMessageId);
+                        if (isOverwrite(rawMessage)) {
+                            /*
+                             * The replacement is now queued and the delete is committed, so the message
+                             * id can be polled again. Cleared here, under the same monitor as the queue
+                             * addition, so no poll can observe the replacement while it is still
+                             * suppressed. The finally below repeats this for the paths that never got
+                             * this far.
+                             */
+                            sourceQueue.clearDeleted(persistedMessageId);
+                        }
+                    }
                 }
 
                 if (responseSelector.canRespond()) {
@@ -1324,6 +1368,20 @@ public class Channel implements Runnable {
                 // TODO determine behavior if this occurs.
                 throw new ChannelException(true, e);
             } finally {
+                /*
+                 * The deleted flag suppresses polling of the message being replaced, so it has to be
+                 * cleared on every path out of here - including the quiesce timeout and any failure
+                 * before the replacement was queued. A flag left set would blackhole every future copy
+                 * of that reused message id. Cleared before releasing the stripe so the next overwrite
+                 * of the same id never observes a stale flag.
+                 */
+                if (overwriteLock != null) {
+                    sourceQueue.clearDeleted(rawMessage.getOriginalMessageId());
+
+                    overwriteLock.unlock();
+                    overwriteLock = null;
+                }
+
                 if (lockAcquired && (!sourceConnector.isRespondAfterProcessing() || persistedMessageId == null || Thread.currentThread().isInterrupted())) {
                     // Release the process lock if an exception was thrown before a message was persisted
                     // or if the thread was interrupted because no additional processing will be done.
@@ -1389,26 +1447,84 @@ public class Channel implements Runnable {
         }
     }
 
-    private void markDeletedQueuedMessages(RawMessage rawMessage, Long persistedMessageId) throws InterruptedException {
-        /*
-         * If the current message has overwritten a previous one, we mark this message as deleted in
-         * all destination queues. This is done so that if a queue thread is currently processing a
-         * message, it will release the message after the current attempt, instead of keeping the
-         * message in memory and trying again. To ensure that all queues are no longer trying to
-         * process this message, we wait until the message is no longer checked out.
-         */
-        if (rawMessage.isOverwrite() && rawMessage.getOriginalMessageId() != null) {
-            // Mark the message as deleted in all queues first
+    private static Lock[] newOverwriteLocks() {
+        Lock[] locks = new Lock[OVERWRITE_LOCK_STRIPES];
+
+        for (int i = 0; i < locks.length; i++) {
+            locks[i] = new ReentrantLock(true);
+        }
+
+        return locks;
+    }
+
+    private boolean isOverwrite(RawMessage rawMessage) {
+        return rawMessage.isOverwrite() && rawMessage.getOriginalMessageId() != null;
+    }
+
+    private Lock getOverwriteLock(Long messageId) {
+        return overwriteLocks[Math.floorMod(messageId, OVERWRITE_LOCK_STRIPES)];
+    }
+
+    /**
+     * If the current message overwrites a previous one, mark that message as deleted in the source
+     * queue and in all destination queues, then wait until it is no longer checked out anywhere. A
+     * queue thread already processing the message releases it after the current attempt instead of
+     * keeping it in memory and trying again, and a copy sitting unprocessed in a queue buffer is
+     * discarded.
+     *
+     * <p>
+     * This must run <b>before</b> the previous message's rows are deleted. An overwrite reuses the
+     * original message id, so a source queue thread that is mid-{@link #process(ConnectorMessage,
+     * boolean)} on the old copy would otherwise commit its destination connector messages after this
+     * pass deleted them, and the next pass's insert would collide on the connector message primary
+     * key (IRT-1655). Waiting first makes overlapping overwrites serialize per message id, so the
+     * last overwrite wins.
+     *
+     * <p>
+     * The caller must not hold the {@code sourceQueue} monitor: the wait below depends on a queue
+     * thread being able to call {@link SourceQueue#finish(ConnectorMessage)}, which is synchronized
+     * on the queue.
+     */
+    private void markDeletedQueuedMessages(RawMessage rawMessage) throws ChannelException, InterruptedException {
+        if (isOverwrite(rawMessage)) {
+            Long messageId = rawMessage.getOriginalMessageId();
+
+            /*
+             * Quiesce the source queue first, and only mark the destination queues once it has
+             * succeeded. The source wait below can abort, and a destination deleted flag that is set
+             * but never consumed makes the destination queue release a message whose row is still
+             * QUEUED, dropping its in-memory count below the database count so it is never acquired
+             * again.
+             */
+            sourceQueue.markAsDeleted(messageId);
+
+            /*
+             * Wait until the message is not checked out in the source queue. Unlike the destination
+             * queues below this wait is bounded: proceeding while the old copy is still in flight is
+             * what causes the primary key collision, so on timeout we fail this dispatch rather than
+             * carry on. That keeps a message wedged in the source queue error-retry loop from holding
+             * an overwriting dispatch, and its process lock permit, indefinitely.
+             */
+            long deadline = System.currentTimeMillis() + Constants.OVERWRITE_QUIESCE_TIMEOUT_MILLIS;
+
+            while (sourceQueue.isCheckedOut(messageId)) {
+                if (System.currentTimeMillis() >= deadline) {
+                    throw new ChannelException(false, null, "Timed out after " + Constants.OVERWRITE_QUIESCE_TIMEOUT_MILLIS + "ms waiting for message " + messageId + " to finish processing in the source queue of channel " + name + " (" + channelId + "), so it was not overwritten. The message may be stuck in the source queue.");
+                }
+
+                Thread.sleep(Constants.OVERWRITE_QUIESCE_POLL_MILLIS);
+            }
+
+            // Mark the message as deleted in all destination queues, then wait out their current attempts
             for (Integer metaDataId : getMetaDataIds()) {
                 if (!metaDataId.equals(0)) {
-                    getDestinationConnector(metaDataId).getQueue().markAsDeleted(persistedMessageId);
+                    getDestinationConnector(metaDataId).getQueue().markAsDeleted(messageId);
                 }
             }
 
-            // Wait until the message is not checked out in all queues
             for (Integer metaDataId : getMetaDataIds()) {
                 if (!metaDataId.equals(0)) {
-                    while (getDestinationConnector(metaDataId).getQueue().isCheckedOut(persistedMessageId)) {
+                    while (getDestinationConnector(metaDataId).getQueue().isCheckedOut(messageId)) {
                         Thread.sleep(100);
                     }
                 }
@@ -1421,7 +1537,7 @@ public class Channel implements Runnable {
         Long messageId;
         Calendar receivedDate;
 
-        if (rawMessage.isOverwrite() && rawMessage.getOriginalMessageId() != null) {
+        if (isOverwrite(rawMessage)) {
             messageId = rawMessage.getOriginalMessageId();
             Set<Integer> metaDataIds = new HashSet<Integer>();
 

--- a/donkey/src/main/java/com/mirth/connect/donkey/server/queue/SourceQueue.java
+++ b/donkey/src/main/java/com/mirth/connect/donkey/server/queue/SourceQueue.java
@@ -23,6 +23,7 @@ import com.mirth.connect.donkey.server.event.MessageEvent;
 public class SourceQueue extends ConnectorMessageQueue {
 
     private Set<Long> checkedOut = Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
+    private Set<Long> deleted = Collections.newSetFromMap(new ConcurrentHashMap<Long, Boolean>());
 
     @Override
     protected ConnectorMessage pollFirstValue() {
@@ -71,8 +72,13 @@ public class SourceQueue extends ConnectorMessageQueue {
              * We use a while loop here to ensure that no message gets polled at the same time from
              * multiple queue threads. After calling poll() and acquiring a connector message, the
              * caller is expected to call finish to remove the message ID from the checked out set.
+             *
+             * Messages marked as deleted are skipped for the same reason. An overwrite defers its
+             * delete to commit time, so until then the previous message's row is still RECEIVED and
+             * fillBuffer() above would hand it back out. Processing that stale copy is what collides
+             * with the replacement on the connector message primary key (IRT-1655).
              */
-            while (connectorMessage != null && checkedOut.contains(connectorMessage.getMessageId())) {
+            while (connectorMessage != null && (checkedOut.contains(connectorMessage.getMessageId()) || deleted.contains(connectorMessage.getMessageId()))) {
                 connectorMessage = pollFirstValue();
             }
         }
@@ -99,9 +105,57 @@ public class SourceQueue extends ConnectorMessageQueue {
         }
     }
 
+    /**
+     * Flags a message as deleted so that the queue stops handing out any copy of it, whether that copy
+     * is already buffered or gets re-read from the database by {@link #fillBuffer()}.
+     *
+     * <p>
+     * Unlike {@link DestinationQueue#markAsDeleted(Long)} the flag is <b>not</b> cleared by
+     * {@link #isCheckedOut(Long)}. It has to stay set until the overwriting dispatch has committed its
+     * delete and queued the replacement, because until that commit the previous message's row is still
+     * RECEIVED and therefore still pollable. The caller must guarantee a matching
+     * {@link #clearDeleted(Long)} - a flag left set would blackhole every future copy of that reused
+     * message id.
+     */
+    public synchronized void markAsDeleted(Long messageId) {
+        deleted.add(messageId);
+    }
+
+    /**
+     * Clears the deleted flag set by {@link #markAsDeleted(Long)}, releasing the message id for
+     * polling again. Must be called on every path out of an overwrite, including failures.
+     */
+    public synchronized void clearDeleted(Long messageId) {
+        deleted.remove(messageId);
+    }
+
+    /**
+     * Mirrors {@link DestinationQueue#isCheckedOut(Long)}. Returns whether a queue thread currently
+     * has the message checked out, and once it no longer does, discards the stale buffered copy.
+     */
+    public synchronized boolean isCheckedOut(Long messageId) {
+        boolean isCheckedOut = checkedOut.contains(messageId);
+
+        if (!isCheckedOut && deleted.contains(messageId)) {
+            /*
+             * Discard the buffered copy so it is not handed out again. Only re-sync the size if a copy
+             * was actually discarded, since that copy was counted in the size. Unlike DestinationQueue
+             * this is conditional: a bulk reprocess calls this once per overwritten message, and an
+             * unconditional re-sync would add a count query per message even when there was nothing to
+             * discard.
+             */
+            if (buffer.remove(messageId) != null) {
+                updateSize();
+            }
+        }
+
+        return isCheckedOut;
+    }
+
     @Override
     protected void reset() {
         checkedOut.clear();
+        deleted.clear();
     }
 
     public synchronized void decrementSize() {

--- a/donkey/src/test/java/com/mirth/connect/donkey/server/queue/SourceQueueTest.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/server/queue/SourceQueueTest.java
@@ -10,10 +10,14 @@
 package com.mirth.connect.donkey.server.queue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +26,8 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import com.mirth.connect.donkey.model.message.ConnectorMessage;
 import com.mirth.connect.donkey.server.event.EventDispatcher;
@@ -65,6 +71,21 @@ public class SourceQueueTest {
             map.put(connectorMessage.getMessageId(), connectorMessage);
         }
         return map;
+    }
+
+    /**
+     * Stubs the data source to return a <b>fresh</b> map on every call, modelling rows that are still
+     * RECEIVED in the database. A plain thenReturn hands back one map instance which fillBuffer assigns
+     * straight to the queue's buffer, so pollFirstValue's iterator.remove() would empty the stub itself
+     * and every later fill would come back empty.
+     */
+    private void stubDatabaseItems(final ConnectorMessage... messages) {
+        when(dataSource.getItems(anyInt(), anyInt())).thenAnswer(new Answer<Map<Long, ConnectorMessage>>() {
+            @Override
+            public Map<Long, ConnectorMessage> answer(InvocationOnMock invocation) {
+                return buffer(messages);
+            }
+        });
     }
 
     @Test
@@ -124,4 +145,164 @@ public class SourceQueueTest {
         // Healthy operation reads the size from the database exactly once (the initial updateSize)
         verify(dataSource).getSize();
     }
+
+    /*
+     * IRT-1655: an overwrite reuses the original message id, so Channel must be able to quiesce the
+     * source queue for that id before deleting the previous message's rows. Otherwise a queue thread
+     * mid-process on the old copy commits its destination connector messages after the delete, and
+     * the next pass's insert collides on the connector message primary key.
+     */
+
+    @Test
+    public void isCheckedOutShouldBeTrueWhileAQueueThreadHoldsTheMessage() {
+        ConnectorMessage inFlight = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(inFlight));
+
+        assertNotNull(queue.poll());
+
+        queue.markAsDeleted(1L);
+
+        // The dispatching thread must wait: the old copy is still being processed
+        assertTrue(queue.isCheckedOut(1L));
+    }
+
+    /**
+     * The overwrite's delete is deferred to commit time, so until then the previous message's row is
+     * still RECEIVED and fillBuffer() will hand it back out. Polling that stale copy is what collides
+     * with the replacement, so poll() has to honour the deleted flag.
+     */
+    @Test
+    public void pollShouldSkipAMessageMarkedAsDeletedEvenWhenReReadFromTheDatabase() {
+        ConnectorMessage stale = message(1);
+        ConnectorMessage other = message(2);
+        when(dataSource.getSize()).thenReturn(2);
+        stubDatabaseItems(stale, other);
+
+        queue.markAsDeleted(1L);
+
+        // The suppressed message must never be handed out, even though the database still returns it
+        assertEquals(2, queue.poll().getMessageId());
+        assertNull(queue.poll());
+    }
+
+    @Test
+    public void pollShouldHandOutTheMessageAgainOnceTheDeletedFlagIsCleared() {
+        ConnectorMessage replacement = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        stubDatabaseItems(replacement);
+
+        queue.markAsDeleted(1L);
+        assertNull(queue.poll());
+
+        // What Channel does once the replacement is committed and queued
+        queue.clearDeleted(1L);
+
+        assertNotNull(queue.poll());
+    }
+
+    @Test
+    public void isCheckedOutShouldNotClearTheDeletedFlag() {
+        ConnectorMessage queued = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        stubDatabaseItems(queued);
+        queue.updateSize();
+        queue.fillBuffer();
+
+        queue.markAsDeleted(1L);
+        assertFalse(queue.isCheckedOut(1L));
+
+        /*
+         * The flag has to outlive the wait: the delete is not committed yet, so clearing it here would
+         * let a queue thread re-read the stale row from the database and process it.
+         */
+        assertNull(queue.poll());
+    }
+
+    @Test
+    public void isCheckedOutShouldEvictTheStaleCopyOnceTheMessageIsFinished() {
+        ConnectorMessage inFlight = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(inFlight));
+
+        assertNotNull(queue.poll());
+        queue.markAsDeleted(1L);
+        assertTrue(queue.isCheckedOut(1L));
+
+        // The in-flight attempt completes and the queue thread releases the message
+        queue.finish(inFlight);
+
+        assertFalse(queue.isCheckedOut(1L));
+        /*
+         * Polling already removed this copy from the buffer and decremented the size, so there is
+         * nothing to discard and no count query is needed
+         */
+        verify(dataSource).getSize();
+
+        /*
+         * Once the overwrite has committed and queued the replacement it clears the flag, and only then
+         * is the replacement handed out - never the copy that was superseded.
+         */
+        ConnectorMessage replacement = message(1);
+        queue.add(replacement);
+        queue.clearDeleted(1L);
+        assertSame(replacement, queue.poll());
+    }
+
+    @Test
+    public void isCheckedOutShouldRemoveAnUnprocessedCopyFromTheBuffer() {
+        ConnectorMessage queued = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(queued));
+        queue.updateSize();
+        queue.fillBuffer();
+        assertTrue(queue.contains(queued));
+
+        // Nothing has polled it yet, so the dispatching thread never waits
+        queue.markAsDeleted(1L);
+        assertFalse(queue.isCheckedOut(1L));
+
+        // ...but the copy it would have handed out is gone
+        assertFalse(queue.contains(queued));
+        // That copy was counted in the size, so the size is re-read
+        verify(dataSource, times(2)).getSize();
+    }
+
+    @Test
+    public void markAsDeletedShouldNotAffectOtherMessages() {
+        ConnectorMessage first = message(1);
+        ConnectorMessage second = message(2);
+        when(dataSource.getSize()).thenReturn(2);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(first, second));
+
+        assertNotNull(queue.poll());
+        queue.markAsDeleted(1L);
+
+        // Message 2 was never marked, so checking it must not touch the buffer or the size
+        assertFalse(queue.isCheckedOut(2L));
+        assertTrue(queue.contains(second));
+        verify(dataSource).getSize();
+    }
+
+    @Test
+    public void resetShouldClearTheDeletedSet() {
+        queue.markAsDeleted(1L);
+
+        // invalidate(reset = true) happens on deploy and on channel start
+        queue.invalidate(false, true);
+
+        ConnectorMessage replacement = message(1);
+        when(dataSource.getSize()).thenReturn(1);
+        when(dataSource.getItems(anyInt(), anyInt())).thenReturn(buffer(replacement));
+        queue.updateSize();
+        queue.fillBuffer();
+
+        /*
+         * A deleted flag that survived the reset would blackhole every future copy of this reused
+         * message id, evicting it from the buffer on the next check.
+         */
+        assertFalse(queue.isCheckedOut(1L));
+        assertTrue(queue.contains(replacement));
+    }
+
 }

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/OverwriteRaceTests.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/OverwriteRaceTests.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.donkey.test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.mirth.connect.donkey.model.message.Status;
+import com.mirth.connect.donkey.server.Donkey;
+import com.mirth.connect.donkey.server.DonkeyConfiguration;
+import com.mirth.connect.donkey.server.DonkeyConnectionPools;
+import com.mirth.connect.donkey.server.StartException;
+import com.mirth.connect.donkey.server.channel.DispatchResult;
+import com.mirth.connect.donkey.server.controllers.ChannelController;
+import com.mirth.connect.donkey.test.util.TestChannel;
+import com.mirth.connect.donkey.test.util.TestSourceConnector;
+import com.mirth.connect.donkey.test.util.TestUtils;
+
+/**
+ * IRT-1655: overlapping "Reprocess and overwrite" passes over the same message on a source-queued
+ * channel used to collide on the connector message primary key. An overwrite reuses the original
+ * message id, so a source queue thread mid-process on the old copy committed its destination
+ * connector messages after the next pass had already deleted them, and that pass's own insert then
+ * violated {@code d_mm<id>_pkey}. The losing transaction rolled back, leaving the source row RECEIVED
+ * so it re-collided on every poll and across restarts.
+ *
+ * <p>
+ * The fix quiesces the source queue for the message id before any of its rows are deleted, so
+ * overlapping overwrites serialize per message and the last one wins.
+ */
+public class OverwriteRaceTests {
+    private static String serverId = TestUtils.DEFAULT_SERVER_ID;
+    private static String testMessage = TestUtils.TEST_HL7_MESSAGE;
+
+    /*
+     * Each test gets its own channel so that a queue thread left wedged by a regression cannot leak
+     * into the next test. Set per test rather than passed around, so the row-count helpers stay terse.
+     */
+    private static volatile String channelId;
+
+    @BeforeClass
+    final public static void beforeClass() throws StartException {
+        Donkey donkey = Donkey.getInstance();
+        DonkeyConfiguration config = TestUtils.getDonkeyTestConfiguration();
+
+        // Close any leaked connection pools from a previously-run test class
+        TestUtils.shutdownConnectionPools();
+        // Initialize connection pools before starting the engine
+        DonkeyConnectionPools.getInstance().init(config.getDonkeyProperties());
+
+        donkey.startEngine(config);
+    }
+
+    @AfterClass
+    final public static void afterClass() throws StartException {
+        Donkey.getInstance().stopEngine();
+        TestUtils.shutdownConnectionPools();
+    }
+
+    /**
+     * An overwrite issued while a source queue thread is still in flight on the previous copy must
+     * wait for that copy to finish before deleting its rows, so its own insert cannot collide.
+     *
+     * <p>
+     * Before the fix this test failed by <i>not</i> blocking: the second pass ran straight through the
+     * (destination-only) overwrite guard while the queue thread was parked, and the resulting
+     * duplicate-key error left the message stuck RECEIVED.
+     */
+    @Test(timeout = 120000)
+    public final void testOverwriteWaitsForInFlightSourceQueueMessage() throws Exception {
+        channelId = "overwriteraceinflight";
+        TestChannel channel = TestUtils.createDefaultChannel(channelId, serverId);
+        // Source queue enabled
+        channel.getSourceConnector().setRespondAfterProcessing(false);
+
+        try {
+            channel.deploy();
+            channel.start(null);
+
+            TestSourceConnector sourceConnector = (TestSourceConnector) channel.getSourceConnector();
+
+            // Get a message through the channel normally so we have an id to overwrite
+            DispatchResult initial = sourceConnector.readTestMessage(testMessage);
+            assertNotNull(initial);
+            Long messageId = initial.getMessageId();
+            awaitProcessed(channel, messageId);
+
+            /*
+             * Park the queue thread inside process() on the first overwrite's copy, which leaves the
+             * message checked out of the source queue with its destination rows not yet committed.
+             */
+            CountDownLatch inFlight = new CountDownLatch(1);
+            CountDownLatch release = new CountDownLatch(1);
+            channel.blockProcessing(messageId, inFlight, release);
+
+            sourceConnector.readTestMessageWithOverwrite(testMessage, messageId);
+            assertTrue("the source queue thread never picked up the first overwrite", inFlight.await(30, TimeUnit.SECONDS));
+
+            // Second overwrite pass over the same message, from another thread
+            final AtomicReference<Throwable> secondPassError = new AtomicReference<Throwable>();
+            final CountDownLatch secondPassDone = new CountDownLatch(1);
+            Thread secondPass = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        ((TestSourceConnector) channel.getSourceConnector()).readTestMessageWithOverwrite(testMessage, messageId);
+                    } catch (Throwable t) {
+                        secondPassError.set(t);
+                    } finally {
+                        secondPassDone.countDown();
+                    }
+                }
+            });
+            secondPass.setName("IRT-1655 second overwrite pass");
+            secondPass.start();
+
+            // It must block: deleting this message's rows while the old copy is in flight is the bug
+            assertFalse("the second overwrite deleted rows while the previous copy was still in flight", secondPassDone.await(3, TimeUnit.SECONDS));
+
+            // Let the in-flight copy finish; the second pass supersedes it
+            release.countDown();
+            assertTrue("the second overwrite never completed", secondPassDone.await(30, TimeUnit.SECONDS));
+            secondPass.join();
+
+            if (secondPassError.get() != null) {
+                throw new AssertionError("the second overwrite pass failed", secondPassError.get());
+            }
+
+            awaitSourceQueueDrained(channel);
+
+            // Exactly one row per connector: no duplicate insert, and nothing left stuck RECEIVED
+            awaitSettled(messageId);
+        } finally {
+            stopAndUndeploy(channel);
+        }
+    }
+
+    /**
+     * Two threads issuing overwrite passes over an overlapping id range must not produce duplicate-key
+     * errors or leave any message stuck RECEIVED.
+     *
+     * <p>
+     * This also covers a second, independent defect found while validating the quiesce above: two
+     * dispatch threads could both quiesce the same message, both see it as not checked out, and then
+     * interleave their deletes and inserts, permanently orphaning a message at RECEIVED with no
+     * duplicate rows, no dispatch error and nothing in the log. Against unmodified HEAD this failed on
+     * roughly one Postgres run in three, and raising the settle wait to 180 seconds did not help - the
+     * message was never polled again. The per-message-id serialization in
+     * {@link Channel#dispatchRawMessage} is what closes it.
+     */
+    @Test(timeout = 240000)
+    public final void testConcurrentOverwritePassesOverOverlappingMessages() throws Exception {
+        final int messageCount = 10;
+        channelId = "overwriteraceconcurrent";
+        TestChannel channel = TestUtils.createDefaultChannel(channelId, serverId);
+        channel.getSourceConnector().setRespondAfterProcessing(false);
+
+        try {
+            channel.deploy();
+            channel.start(null);
+
+            final TestSourceConnector sourceConnector = (TestSourceConnector) channel.getSourceConnector();
+
+            // Seed the channel
+            final List<Long> messageIds = new ArrayList<Long>();
+            for (int i = 0; i < messageCount; i++) {
+                messageIds.add(sourceConnector.readTestMessage(testMessage).getMessageId());
+            }
+            awaitSourceQueueDrained(channel);
+
+            // Two passes over the same ids, in opposite order so they interleave
+            final List<Throwable> errors = Collections.synchronizedList(new ArrayList<Throwable>());
+            List<Thread> passes = new ArrayList<Thread>();
+
+            for (int pass = 0; pass < 2; pass++) {
+                final boolean reverse = pass == 1;
+                Thread thread = new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        List<Long> ids = new ArrayList<Long>(messageIds);
+                        if (reverse) {
+                            Collections.reverse(ids);
+                        }
+
+                        for (Long messageId : ids) {
+                            try {
+                                sourceConnector.readTestMessageWithOverwrite(testMessage, messageId);
+                            } catch (Throwable t) {
+                                errors.add(t);
+                            }
+                        }
+                    }
+                });
+                thread.setName("IRT-1655 overwrite pass " + (pass + 1));
+                passes.add(thread);
+            }
+
+            for (Thread thread : passes) {
+                thread.start();
+            }
+            for (Thread thread : passes) {
+                thread.join(TimeUnit.MINUTES.toMillis(2));
+                assertFalse("an overwrite pass did not finish", thread.isAlive());
+            }
+
+            if (!errors.isEmpty()) {
+                throw new AssertionError("overwrite passes reported " + errors.size() + " error(s), first: " + errors.get(0), errors.get(0));
+            }
+
+            awaitSourceQueueDrained(channel);
+
+            /*
+             * Every message must have exactly one row per connector and must not be left RECEIVED. A
+             * duplicate-key rollback shows up here as a message stuck RECEIVED that the queue thread
+             * re-attempts forever.
+             */
+            for (Long messageId : messageIds) {
+                awaitSettled(messageId);
+            }
+        } finally {
+            stopAndUndeploy(channel);
+        }
+    }
+
+    private static int countConnectorMessageRows(long messageId, int metaDataId) throws Exception {
+        long localChannelId = ChannelController.getInstance().getLocalChannelId(channelId);
+        Connection connection = null;
+        PreparedStatement statement = null;
+        ResultSet result = null;
+
+        try {
+            connection = TestUtils.getConnection();
+            statement = connection.prepareStatement("SELECT COUNT(*) FROM D_MM" + localChannelId + " WHERE message_id = ? AND id = ?");
+            statement.setLong(1, messageId);
+            statement.setInt(2, metaDataId);
+            result = statement.executeQuery();
+            result.next();
+            return result.getInt(1);
+        } finally {
+            TestUtils.close(result);
+            TestUtils.close(statement);
+            TestUtils.close(connection);
+        }
+    }
+
+    private static void awaitProcessed(TestChannel channel, long messageId) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(20);
+
+        while (System.currentTimeMillis() < deadline) {
+            if (TestUtils.isMessageProcessed(channelId, messageId)) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+
+        fail("message " + messageId + " was never processed - a duplicate-key rollback leaves the source row RECEIVED and it re-errors on every poll");
+    }
+
+    /**
+     * Waits until a message has settled into its expected final shape: exactly one row per connector
+     * and a source status of TRANSFORMED.
+     *
+     * <p>
+     * This has to be a wait rather than a bare assertion. {@link SourceQueue#poll()} decrements the
+     * queue size when a message is checked out, not when it finishes, so a drained queue does not mean
+     * the last copy is done - it can still be mid-process with its destination row not yet inserted
+     * and its source row still RECEIVED. A message genuinely wedged by a duplicate-key rollback never
+     * reaches this state, so the bounded wait still catches the regression.
+     */
+    private static void awaitSettled(long messageId) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30);
+        int sourceRows = -1;
+        int destinationRows = -1;
+        Status sourceStatus = null;
+
+        while (System.currentTimeMillis() < deadline) {
+            sourceRows = countConnectorMessageRows(messageId, 0);
+            destinationRows = countConnectorMessageRows(messageId, 1);
+            sourceStatus = getConnectorMessageStatus(messageId, 0);
+
+            if (sourceRows == 1 && destinationRows == 1 && sourceStatus == Status.TRANSFORMED) {
+                return;
+            }
+
+            Thread.sleep(50);
+        }
+
+        fail("message " + messageId + " never settled - source rows: " + sourceRows + " (expected 1), destination rows: " + destinationRows + " (expected 1), source status: " + sourceStatus + " (expected TRANSFORMED). More than one row means the overwrite inserted a duplicate; a source row stuck RECEIVED means a duplicate-key rollback left it re-erroring on every poll.");
+    }
+
+    private static Status getConnectorMessageStatus(long messageId, int metaDataId) throws Exception {
+        long localChannelId = ChannelController.getInstance().getLocalChannelId(channelId);
+        Connection connection = null;
+        PreparedStatement statement = null;
+        ResultSet result = null;
+
+        try {
+            connection = TestUtils.getConnection();
+            statement = connection.prepareStatement("SELECT status FROM D_MM" + localChannelId + " WHERE message_id = ? AND id = ?");
+            statement.setLong(1, messageId);
+            statement.setInt(2, metaDataId);
+            result = statement.executeQuery();
+
+            if (!result.next()) {
+                return null;
+            }
+
+            return Status.fromChar(result.getString("status").charAt(0));
+        } finally {
+            TestUtils.close(result);
+            TestUtils.close(statement);
+            TestUtils.close(connection);
+        }
+    }
+
+    private static void awaitSourceQueueDrained(TestChannel channel) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(20);
+
+        while (System.currentTimeMillis() < deadline) {
+            if (channel.getSourceQueue().size() == 0) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+
+        fail("the source queue never drained, size is " + channel.getSourceQueue().size() + " - a message that collides on every poll never leaves the queue");
+    }
+
+    /**
+     * Halts rather than stops. A regression in the overwrite guard leaves a queue thread wedged
+     * re-attempting a message that collides on every poll, and {@code stop()} would block joining it,
+     * replacing the real assertion failure with a test timeout.
+     */
+    private static void stopAndUndeploy(TestChannel channel) {
+        try {
+            channel.halt();
+        } catch (Exception e) {
+            // Nothing useful to do during cleanup
+        }
+
+        try {
+            channel.undeploy();
+            ChannelController.getInstance().removeChannel(channelId);
+        } catch (Exception e) {
+            // Nothing useful to do during cleanup
+        }
+    }
+}

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestChannel.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestChannel.java
@@ -11,6 +11,8 @@ package com.mirth.connect.donkey.test.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.mirth.connect.donkey.model.message.ConnectorMessage;
 import com.mirth.connect.donkey.model.message.Message;
@@ -28,6 +30,11 @@ public class TestChannel extends Channel {
     private boolean isDeployed = false;
     private volatile boolean queueThreadRunning = false;
     private List<Message> unfinishedMessages = null;
+
+    private volatile Long blockedMessageId;
+    private volatile CountDownLatch processEntered;
+    private volatile CountDownLatch processRelease;
+    private final AtomicBoolean blockConsumed = new AtomicBoolean();
 
     public TestChannel() {
         super();
@@ -83,8 +90,34 @@ public class TestChannel extends Channel {
         super.queue(sourceMessage);
     }
 
+    /**
+     * Parks the next {@link #process(ConnectorMessage, boolean)} call for the given message id until
+     * {@code release} is counted down, so a test can hold a source queue thread in flight on a
+     * specific message. One-shot: later attempts on the same message id are not blocked.
+     *
+     * @param entered
+     *            counted down once the queue thread is inside process (and therefore checked out of
+     *            the source queue)
+     * @param release
+     *            awaited before the message is actually processed
+     */
+    public void blockProcessing(Long messageId, CountDownLatch entered, CountDownLatch release) {
+        blockConsumed.set(false);
+        this.processEntered = entered;
+        this.processRelease = release;
+        // Published last: process() reads the latches only after matching this, so they are never null
+        this.blockedMessageId = messageId;
+    }
+
     @Override
     public Message process(ConnectorMessage sourceMessage, boolean markAsProcessed) throws InterruptedException {
+        Long blocked = blockedMessageId;
+
+        if (blocked != null && blocked.equals(sourceMessage.getMessageId()) && blockConsumed.compareAndSet(false, true)) {
+            processEntered.countDown();
+            processRelease.await();
+        }
+
         Message message = super.process(sourceMessage, markAsProcessed);
         messageIds.add(message.getMessageId());
         return message;

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestSourceConnector.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestSourceConnector.java
@@ -62,7 +62,22 @@ public class TestSourceConnector extends SourceConnector {
     }
 
     public DispatchResult readTestMessage(String raw) throws ChannelException {
+        return dispatch(new RawMessage(raw));
+    }
+
+    /**
+     * Dispatches a raw message that overwrites an existing one, the way "Reprocess and overwrite"
+     * does. The overwritten message keeps its original message id.
+     */
+    public DispatchResult readTestMessageWithOverwrite(String raw, Long originalMessageId) throws ChannelException {
         RawMessage rawMessage = new RawMessage(raw);
+        rawMessage.setOverwrite(true);
+        rawMessage.setOriginalMessageId(originalMessageId);
+
+        return dispatch(rawMessage);
+    }
+
+    private DispatchResult dispatch(RawMessage rawMessage) throws ChannelException {
         DispatchResult dispatchResult = null;
 
         try {


### PR DESCRIPTION
## Summary

Overlapping "Reprocess and overwrite" jobs on a **source-queued** channel could fail with duplicate-key errors on the connector message table and leave the affected messages erroring repeatedly, including across channel restarts. Observed in production on a single-node instance backed by Postgres during bulk reprocessing by concurrent jobs.

This fixes two distinct defects on that path. Both require a source-queued channel (Queue Messages on / Respond: Auto-generate Before Processing) and an overwrite, which reuses the original message id rather than allocating a new one.

### 1. Overwrite could delete rows out from under an in-flight message

The overwrite guard covered destination queues only, and ran *after* the previous message's rows had already been deleted. `SourceQueue` had no deleted-message machinery at all, so a source queue thread already processing the previous copy was never told to stop. It committed its destination connector message insert after the next pass had deleted those rows, and that pass's own insert then violated `d_mm<localChannelId>_pkey`. The losing transaction rolled back, leaving the source row RECEIVED, so the message re-collided on every poll and survived restarts via recovery.

Fixed by giving `SourceQueue` the deleted-message coordination `DestinationQueue` already had, and quiescing the source queue for the message id *before* any of its rows are deleted.

Because the delete is deferred to commit time by `BufferedDao`, the previous message's row stays RECEIVED — and therefore pollable — until that commit. `SourceQueue.poll()` now honours the deleted flag so a row re-read from the database in that window is discarded rather than handed to a queue thread.

### 2. Concurrent overwrites of the same message could silently orphan it

`markDeletedQueuedMessages` and the delete/insert in `createAndStoreSourceMessage` were not mutually exclusive between dispatch threads — the existing `synchronized (sourceQueue)` block covers only the commit and the queue addition. Two dispatchers could both quiesce the same message, both observe it as not checked out, then interleave their deletes and inserts. One pass's queued copy was discarded from the buffer while its row stayed RECEIVED and the queue size no longer accounted for it, so nothing polled it again.

This produced no error and no log entry: the message simply stopped, needing a further overwrite or delete to clear. Fixed with striped per-message-id locks held across the whole critical section (quiesce, delete, insert, commit, queue), acquired only for overwrite dispatches so normal message flow is unaffected.

## Operator-visible changes

- Overlapping reprocess-overwrite jobs on a source-queued channel no longer produce `d_mm<id>_pkey` violations, and no longer leave messages stuck RECEIVED. The last overwrite wins.
- The workaround of serialising bulk reprocess jobs, or preferring non-overwrite reprocess, is no longer required.
- An overwrite now waits for the previous copy of that message to finish processing. If it cannot within 5 minutes (`OVERWRITE_QUIESCE_TIMEOUT_MILLIS`), that single message's overwrite fails with a `ChannelException` naming the message id, and is logged; the rest of the job continues. Proceeding regardless is what caused the corruption, so failing loudly is deliberate. This is a new error condition that did not previously exist.
- Overwrites of the *same* message id are serialised against each other. Overwrites of different messages, and all non-overwrite traffic, are unaffected.

## Changes

| File | Change |
|---|---|
| `donkey/.../queue/SourceQueue.java` | `deleted` set with `markAsDeleted` / `clearDeleted` / `isCheckedOut`; `poll()` skips suppressed message ids; `reset()` clears the set |
| `donkey/.../channel/Channel.java` | Overwrite guard moved before the destructive delete and extended to the source queue; two call sites collapsed to one; striped per-message-id overwrite locks; bounded source-queue quiesce wait |
| `donkey/.../server/Constants.java` | `OVERWRITE_QUIESCE_TIMEOUT_MILLIS`, `OVERWRITE_QUIESCE_POLL_MILLIS` |

## Testing

`OverwriteRaceTests` is new; no existing test anywhere exercised `RawMessage.isOverwrite()` or the `markAsDeleted` / `releaseIfDeleted` path, so this is first coverage for it. `TestChannel.blockProcessing` and `TestSourceConnector.readTestMessageWithOverwrite` are the supporting harness hooks.

Verified against Postgres, where the production failure occurred:

| Test | Unmodified base | With this change |
|---|---|---|
| Overwrite while previous copy in flight (deterministic) | fails 4/4 | passes |
| Concurrent overwrite passes over an overlapping id range | fails 2/4 | 8/8 clean |

Full donkey suite: 161 tests, no failures, on both Derby and Postgres.

The concurrency test is retained and enabled. It was the reproducer for defect 2 and is the regression guard for it; it needs Postgres (`ant test-run-postgres-db`) to exercise the interleaving reliably.

### Pre-existing suite flakiness (IRT-1788)

Two donkey tests unrelated to this change fail intermittently, so an individual suite run may come back red for reasons that have nothing to do with this PR. Both are tracked in IRT-1788, and both were confirmed pre-existing by reproducing them against the unmodified base:

* `ChannelTests.testContentRemoval` — deadlock in test setup between the harness statistics delete and the background statistics updater. Roughly 1 run in 8, reproduced with the class run in isolation.
* `ConnectorTests.testPollConnector` — wall-clock assertion expecting exactly 7 polls in 6800 ms; returns 6 under load. Confirmed pre-existing by interleaved A/B runs against prebuilt pre-fix and post-fix class trees (base 4/8 vs this branch 1/8, i.e. no attributable difference).

## Notes for reviewers

- A single channel-wide overwrite lock was prototyped and rejected: it escalates one wedged message into a channel-wide stall, because the dispatcher waits on a message the queue thread keeps re-acquiring in its error-retry loop while holding both that lock and a process lock permit. Hence striping by message id.
- `SourceQueue.isCheckedOut` deliberately diverges from `DestinationQueue`'s: its size re-sync is conditional on a buffered copy actually being discarded, to avoid a count query per message during bulk reprocess.
- The destination-queue wait is intentionally left unbounded. Bounding it would change behaviour on a path this ticket does not address, where an overwrite can legitimately wait out a slow destination send.
- Defect 1 was diagnosed by tracing the deferred-delete window rather than by reproduction; the deterministic test covers the in-flight case it derives from, but the specific re-read interleaving was not reproduced in isolation.

Fixes IRT-1655.
