### PR TITLE
fix(donkey): fix two flaky donkey tests (IRT-1788)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,18 @@ donkey/donkey-test
 **/code-coverage-reports
 **/junit-html
 **/jacoco-html
+
+# Per-database test report output (ant test-run-<db>-db writes <dir>-<dbtype>); gitignore matches
+# whole path components, so the patterns above do not cover these.
+**/junit-reports-*
+**/code-coverage-reports-*
+**/junit-html-*
+**/jacoco-html-*
+
+# Temp files ant's forked <junit> task writes into the module directory; they leak when a forked
+# JVM is killed.
+**/junit[0-9]*.properties
+**/junitvmwatcher*.properties
 .DS_Store
 
 # /client/

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/ConnectorTests.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/ConnectorTests.java
@@ -72,8 +72,14 @@ public class ConnectorTests {
      * whole-second boundaries. A 6800 ms window only contains 7 of those boundaries when it happens
      * to start at least 200 ms into a second, so ~20% of runs saw 6 polls on a completely idle
      * machine, before machine load was a factor at all. Waiting for the polls removes the
-     * dependency on wall clock; the elapsed-time assertion below still holds the polling frequency
-     * itself to account.
+     * dependency on wall clock.
+     *
+     * The elapsed-time assertion below bounds the polling frequency from one side only: it catches
+     * polls firing faster than configured, or the interval being ignored entirely, but not polls
+     * firing slower than configured. That is deliberate - an upper bound would have to tolerate a
+     * loaded machine and a slow database, and PollConnectorJob silently drops a fire whose
+     * predecessor is still running, so any upper bound loose enough to be stable would be too loose
+     * to catch a real regression. It would put the wall-clock flakiness straight back.
      */
     @Test
     public final void testPollConnector() throws Exception {
@@ -159,7 +165,7 @@ public class ConnectorTests {
 
         assertTrue("Expected " + expectedPollCount + " polls within " + pollTimeoutMillis + "ms but only " + actualPollCount + " completed", reachedExpectedPolls);
         // Polls are spaced by the polling frequency, so reaching the expected count any faster
-        // would mean the frequency was not honored.
+        // would mean the frequency was not honored at all.
         assertTrue("Expected " + expectedPollCount + " polls to take at least " + ((expectedPollCount - 1) * pollingFrequency) + "ms but took " + elapsedMillis + "ms", elapsedMillis >= (expectedPollCount - 1) * pollingFrequency);
         // Every poll dispatches exactly one message. Not asserted against expectedPollCount
         // directly: a further poll may fire between the latch opening and stop() completing.

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/ConnectorTests.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/ConnectorTests.java
@@ -10,6 +10,11 @@
 package com.mirth.connect.donkey.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.mirth.connect.donkey.test.util.TestConnectorProperties;
 import com.mirth.connect.donkey.test.util.TestResponseTransformer;
@@ -27,7 +32,6 @@ import com.mirth.connect.donkey.server.DonkeyConnectionPools;
 import com.mirth.connect.donkey.server.StartException;
 import com.mirth.connect.donkey.server.channel.DestinationChainProvider;
 import com.mirth.connect.donkey.server.channel.MetaDataReplacer;
-import com.mirth.connect.donkey.server.channel.SourceConnector;
 import com.mirth.connect.donkey.server.controllers.ChannelController;
 import com.mirth.connect.donkey.test.util.TestChannel;
 import com.mirth.connect.donkey.test.util.TestDataType;
@@ -59,17 +63,25 @@ public class ConnectorTests {
     }
 
     /*
-     * Create a new poll connector channel Set the polling frequency to 500 ms Starts the channel,
-     * waits 3250 ms, asserts that: - 7 messages are processed by the channel
+     * Creates a poll connector channel with a 1000 ms polling frequency, waits until 7 polls have
+     * completed, and asserts that each poll produced exactly one processed message.
+     *
+     * IRT-1788: this used to sleep 6800 ms and assert exactly 7 polls, which failed roughly 1 run
+     * in 4. Quartz anchors an interval trigger at midnight rather than at channel.start()
+     * (TriggerFactory.createDailyInterval), and pollOnStart is false, so polls fire on absolute
+     * whole-second boundaries. A 6800 ms window only contains 7 of those boundaries when it happens
+     * to start at least 200 ms into a second, so ~20% of runs saw 6 polls on a completely idle
+     * machine, before machine load was a factor at all. Waiting for the polls removes the
+     * dependency on wall clock; the elapsed-time assertion below still holds the polling frequency
+     * itself to account.
      */
     @Test
     public final void testPollConnector() throws Exception {
         final int pollingFrequency = 1000;
-        // Polls fire at t=0, 1000, 2000, 3000, 4000, 5000, 6000ms (7 total).
-        // 6800ms gives 800ms buffer for the 7th poll to complete on slow DBs (MySQL)
-        // while stopping before the 8th poll fires at t=7000ms.
-        final int sleepMillis = 6800;
-        final int expectedMessageCount = 7;
+        final int expectedPollCount = 7;
+        // 7 polls need at least 6 s of wall clock, so this is generous margin for a loaded machine
+        // rather than a timing assumption - only the failure path waits this long.
+        final long pollTimeoutMillis = 30000L;
 
         String channelId = TestUtils.DEFAULT_CHANNEL_ID;
         String serverId = TestUtils.DEFAULT_SERVER_ID;
@@ -90,7 +102,7 @@ public class ConnectorTests {
         ((PollConnectorPropertiesInterface) connectorProperties).getPollConnectorProperties().setPollingType(PollingType.INTERVAL);
         ((PollConnectorPropertiesInterface) connectorProperties).getPollConnectorProperties().setPollingFrequency(pollingFrequency);
 
-        SourceConnector sourceConnector = new TestPollConnector();
+        CountingPollConnector sourceConnector = new CountingPollConnector(expectedPollCount);
         sourceConnector.setConnectorProperties(connectorProperties);
         sourceConnector.setInboundDataType(new TestDataType());
         sourceConnector.setOutboundDataType(new TestDataType());
@@ -132,11 +144,53 @@ public class ConnectorTests {
         channel.setProcessLock(processLock);
 
         channel.deploy();
+
+        long startNanos = System.nanoTime();
         channel.start(null);
-        Thread.sleep(sleepMillis);
+        boolean reachedExpectedPolls = sourceConnector.awaitPolls(pollTimeoutMillis, TimeUnit.MILLISECONDS);
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+
+        // stop() shuts the Quartz scheduler down and waits for any in-flight poll, so the counts
+        // below are stable once it returns.
         channel.stop();
         channel.undeploy();
 
-        assertEquals(expectedMessageCount, channel.getNumMessages());
+        int actualPollCount = sourceConnector.getPollCount();
+
+        assertTrue("Expected " + expectedPollCount + " polls within " + pollTimeoutMillis + "ms but only " + actualPollCount + " completed", reachedExpectedPolls);
+        // Polls are spaced by the polling frequency, so reaching the expected count any faster
+        // would mean the frequency was not honored.
+        assertTrue("Expected " + expectedPollCount + " polls to take at least " + ((expectedPollCount - 1) * pollingFrequency) + "ms but took " + elapsedMillis + "ms", elapsedMillis >= (expectedPollCount - 1) * pollingFrequency);
+        // Every poll dispatches exactly one message. Not asserted against expectedPollCount
+        // directly: a further poll may fire between the latch opening and stop() completing.
+        assertEquals(actualPollCount, channel.getNumMessages());
+    }
+
+    /**
+     * Counts completed polls so a test can wait for them instead of sleeping for a fixed time.
+     * Mirrors the CountDownJob pattern in PollConnectorJobTests.
+     */
+    private static class CountingPollConnector extends TestPollConnector {
+        private final AtomicInteger pollCount = new AtomicInteger();
+        private final CountDownLatch latch;
+
+        CountingPollConnector(int expectedPolls) {
+            latch = new CountDownLatch(expectedPolls);
+        }
+
+        @Override
+        protected void poll() {
+            super.poll();
+            pollCount.incrementAndGet();
+            latch.countDown();
+        }
+
+        boolean awaitPolls(long timeout, TimeUnit unit) throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+
+        int getPollCount() {
+            return pollCount.get();
+        }
     }
 }

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
@@ -19,6 +19,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
+import java.lang.reflect.Field;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -27,12 +28,15 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -75,12 +79,14 @@ import com.mirth.connect.donkey.server.channel.MetaDataReplacer;
 import com.mirth.connect.donkey.server.channel.ResponseSelector;
 import com.mirth.connect.donkey.server.channel.ResponseTransformerExecutor;
 import com.mirth.connect.donkey.server.channel.SourceConnector;
+import com.mirth.connect.donkey.server.channel.Statistics;
 import com.mirth.connect.donkey.server.channel.StorageSettings;
 import com.mirth.connect.donkey.server.channel.components.ResponseTransformer;
 import com.mirth.connect.donkey.server.controllers.ChannelController;
 import com.mirth.connect.donkey.server.data.DonkeyDao;
 import com.mirth.connect.donkey.server.data.DonkeyDaoException;
 import com.mirth.connect.donkey.server.data.DonkeyDaoFactory;
+import com.mirth.connect.donkey.server.data.DonkeyStatisticsUpdater;
 import com.mirth.connect.donkey.server.data.buffered.BufferedDaoFactory;
 import com.mirth.connect.donkey.server.data.passthru.PassthruDaoFactory;
 import com.mirth.connect.donkey.server.event.EventDispatcher;
@@ -106,6 +112,25 @@ public class TestUtils {
     final public static String DEFAULT_OUTBOUND_TEMPLATE = null;
 
     private static Logger logger = LogManager.getLogger(TestUtils.class);
+
+    /*
+     * IRT-1788: bounded retry for statements that contend with the Statistics Updater thread.
+     * Whichever transaction the database picks as the deadlock victim, the other one committed, so
+     * one retry is normally enough. The backoffs are unequal and are not multiples of the updater's
+     * 1000 ms tick, so a retry cannot stay phase-locked to the tick and collide at the same offset
+     * every attempt; together they span more than one full tick.
+     */
+    private static final int LOCK_RETRY_ATTEMPTS = 4;
+    private static final long[] LOCK_RETRY_BACKOFF_MILLIS = { 150L, 400L, 900L };
+
+    /*
+     * Derby: 40001 deadlock, 40XL1/40XL2 lock timeout.
+     * PostgreSQL: 40001 serialization failure, 40P01 deadlock detected, 55P03 lock not available.
+     */
+    private static final Set<String> TRANSIENT_LOCK_SQL_STATES = new HashSet<String>(Arrays.asList("40001", "40XL1", "40XL2", "40P01", "55P03"));
+
+    private static Field pendingStatisticsField;
+    private static boolean pendingStatisticsWarningLogged;
 
     /**
      * Closes HikariCP connection pools held by DonkeyConnectionPools.
@@ -1286,22 +1311,240 @@ public class TestUtils {
         return stats;
     }
 
+    /**
+     * Resets the statistics for a channel, both in the database and in memory.
+     *
+     * IRT-1788: the Statistics Updater thread (DonkeyStatisticsUpdater) runs for the entire
+     * lifetime of a test class and writes D_MS&lt;localChannelId&gt; on its own schedule, so a plain
+     * "DELETE FROM D_MS&lt;n&gt;" here races it in two different ways:
+     *
+     * 1. Derby detects a row-lock cycle between our DELETE and the updater's UPDATE and rolls one
+     *    of the two transactions back, failing whatever test happened to be in setup.
+     * 2. A flush landing after our DELETE finds no rows to UPDATE, so JdbcDao falls through to
+     *    insertChannelStatistics and re-creates the rows with the previous test's counts, while
+     *    the in-memory statistics we cleared still read zero.
+     *
+     * Both come from the same defect - nothing coordinates harness cleanup with the updater - so
+     * this first takes the updater's pending deltas for this channel away from it, then deletes
+     * with a retry for a flush that was already in flight, then verifies the rows really are gone.
+     */
     public static void deleteChannelStatistics(String channelId) throws SQLException {
-        long localChannelId = ChannelController.getInstance().getLocalChannelId(channelId);
-        Connection connection = null;
+        final long localChannelId = ChannelController.getInstance().getLocalChannelId(channelId);
+        final String sql = "DELETE FROM D_MS" + localChannelId;
+
+        discardPendingStatistics(channelId);
+        executeWithLockRetry(sql, connection -> executeUpdate(connection, sql));
+
+        /*
+         * Deliberately after the DELETE, and deliberately not in a finally block: DonkeyDaoTests
+         * and ChannelControllerTests assert that the database and the in-memory statistics agree,
+         * so the two must be cleared together or not at all. Clearing memory on a path where the
+         * DELETE failed would leave memory at zero and the database stale, which surfaces as a
+         * confusing wrong-value assertion much later instead of the real error here.
+         */
+        Statistics statistics = ChannelController.getInstance().getStatistics();
+
+        if (statistics != null) {
+            statistics.remove(channelId);
+        }
+
+        /*
+         * If a flush committed between the discard and the DELETE, the rows are back. Repair once:
+         * the updater's pending deltas now hold the negated snapshot it re-applies after a
+         * successful commit, so they have to be discarded again along with the rows.
+         */
+        if (countStatisticsRows(localChannelId) > 0) {
+            logger.warn("Statistics rows for channel " + channelId + " were re-created by the Statistics Updater during cleanup; repairing (IRT-1788).");
+            discardPendingStatistics(channelId);
+            executeWithLockRetry(sql, connection -> executeUpdate(connection, sql));
+        }
+    }
+
+    /**
+     * Takes away whatever the Statistics Updater is still holding in memory for this channel, so
+     * that its next tick cannot write counts back into a table the caller is about to empty.
+     *
+     * DonkeyStatisticsUpdater keeps its pending deltas in a private field with no accessor and
+     * exposes no way to pause or flush, so the field is read reflectively. This is test-harness
+     * code and product code is deliberately left alone; if the field is ever renamed, the harness
+     * logs a warning and falls back to its previous (racy) behavior rather than breaking.
+     *
+     * Only safe because every caller resets statistics before generating the traffic it asserts
+     * on - the discarded deltas belong to traffic the test is throwing away.
+     */
+    private static void discardPendingStatistics(String channelId) {
+        DonkeyStatisticsUpdater updater = Donkey.getInstance().getStatisticsUpdater();
+
+        if (updater == null) {
+            // Engine not started yet, so there is no updater thread to race with.
+            return;
+        }
+
+        try {
+            if (pendingStatisticsField == null) {
+                Field field = DonkeyStatisticsUpdater.class.getDeclaredField("statistics");
+                field.setAccessible(true);
+                pendingStatisticsField = field;
+            }
+
+            Statistics pendingStatistics = (Statistics) pendingStatisticsField.get(updater);
+
+            if (pendingStatistics != null) {
+                // Scoped to this channel, not clear(), so multi-channel tests keep the rest.
+                pendingStatistics.remove(channelId);
+            }
+        } catch (Exception e) {
+            if (!pendingStatisticsWarningLogged) {
+                pendingStatisticsWarningLogged = true;
+                logger.warn("Unable to reach the Statistics Updater's pending statistics; channel statistics cleanup may race the updater thread (IRT-1788).", e);
+            }
+        }
+    }
+
+    private static void executeUpdate(Connection connection, String sql) throws SQLException {
         PreparedStatement statement = null;
 
         try {
-            connection = getConnection();
-            statement = connection.prepareStatement("DELETE FROM D_MS" + localChannelId);
+            statement = connection.prepareStatement(sql);
             statement.executeUpdate();
-            connection.commit();
         } finally {
             close(statement);
-            close(connection);
+        }
+    }
+
+    private static long countStatisticsRows(long localChannelId) throws SQLException {
+        final String sql = "SELECT COUNT(*) FROM D_MS" + localChannelId;
+
+        return callWithLockRetry(sql, connection -> {
+            PreparedStatement statement = null;
+            ResultSet result = null;
+
+            try {
+                statement = connection.prepareStatement(sql);
+                result = statement.executeQuery();
+                return result.next() ? result.getLong(1) : 0L;
+            } finally {
+                close(result);
+                close(statement);
+            }
+        });
+    }
+
+    private interface ConnectionCallable<T> {
+        T call(Connection connection) throws SQLException;
+    }
+
+    private interface ConnectionRunnable {
+        void run(Connection connection) throws SQLException;
+    }
+
+    private static void executeWithLockRetry(String description, ConnectionRunnable action) throws SQLException {
+        callWithLockRetry(description, connection -> {
+            action.run(connection);
+            return null;
+        });
+    }
+
+    /**
+     * Runs an action in its own transaction, retrying it on a transient lock failure.
+     *
+     * The action MUST be idempotent: every attempt gets a fresh connection and a fresh
+     * transaction, and a failed attempt is rolled back by close(Connection). Retries are bounded
+     * and the last SQLException is rethrown once they are exhausted, so a genuine database problem
+     * still fails the test - just later, with the SQLState logged.
+     */
+    private static <T> T callWithLockRetry(String description, ConnectionCallable<T> action) throws SQLException {
+        SQLException lastException = null;
+
+        for (int attempt = 1; attempt <= LOCK_RETRY_ATTEMPTS; attempt++) {
+            Connection connection = null;
+
+            try {
+                connection = getConnection();
+                T value = action.call(connection);
+                connection.commit();
+
+                if (attempt > 1) {
+                    logger.warn("\"" + description + "\" succeeded on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + " after transient lock contention (IRT-1788).");
+                }
+
+                return value;
+            } catch (SQLException e) {
+                lastException = e;
+
+                if (attempt == LOCK_RETRY_ATTEMPTS || !isTransientLockFailure(e)) {
+                    throw e;
+                }
+
+                logger.warn("\"" + description + "\" hit a transient lock failure (SQLState=" + e.getSQLState() + ", errorCode=" + e.getErrorCode() + ") on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + "; retrying. This is normally contention with the Statistics Updater thread (IRT-1788).", e);
+            } finally {
+                // close(Connection) rolls back first, so a failed attempt leaves no open
+                // transaction on the pooled connection.
+                close(connection);
+            }
+
+            try {
+                Thread.sleep(LOCK_RETRY_BACKOFF_MILLIS[attempt - 1]);
+            } catch (InterruptedException e) {
+                // Do not swallow a @Test(timeout=...) interrupt: stop retrying and report the
+                // database failure instead.
+                Thread.currentThread().interrupt();
+                throw lastException;
+            }
         }
 
-        ChannelController.getInstance().getStatistics().remove(channelId);
+        throw lastException;
+    }
+
+    /**
+     * Whether a failure means "the transaction was rolled back through no fault of the statement",
+     * i.e. re-running an idempotent statement is expected to succeed.
+     *
+     * An exact SQLState allowlist rather than a "40" class prefix: Derby's class 40 also contains
+     * 40XC0 (dead statement) and 40XD0-40XD2 (container closed), none of which is lock contention.
+     */
+    static boolean isTransientLockFailure(Throwable throwable) {
+        Set<Throwable> seen = Collections.newSetFromMap(new IdentityHashMap<Throwable, Boolean>());
+        Deque<Throwable> pending = new ArrayDeque<Throwable>();
+
+        // ArrayDeque rejects nulls, and an unchained exception is the common case, so every add
+        // has to be guarded.
+        addIfNotNull(pending, throwable);
+
+        while (!pending.isEmpty()) {
+            Throwable current = pending.poll();
+
+            // SQLException chains link through both getCause() and getNextException(), and those
+            // can cross-link, so track what has already been visited.
+            if (!seen.add(current)) {
+                continue;
+            }
+
+            if (current instanceof SQLException) {
+                SQLException sqlException = (SQLException) current;
+
+                if (TRANSIENT_LOCK_SQL_STATES.contains(StringUtils.upperCase(sqlException.getSQLState()))) {
+                    return true;
+                }
+
+                addIfNotNull(pending, sqlException.getNextException());
+            }
+
+            // Fallback for drivers that report a useless SQLState (MySQL lock waits, Oracle).
+            if (StringUtils.containsAnyIgnoreCase(current.getMessage(), "deadlock", "lock could not be obtained", "lock wait timeout")) {
+                return true;
+            }
+
+            addIfNotNull(pending, current.getCause());
+        }
+
+        return false;
+    }
+
+    private static void addIfNotNull(Deque<Throwable> pending, Throwable throwable) {
+        if (throwable != null) {
+            pending.add(throwable);
+        }
     }
 
     /**

--- a/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
+++ b/donkey/src/test/java/com/mirth/connect/donkey/test/util/TestUtils.java
@@ -124,6 +124,13 @@ public class TestUtils {
     private static final long[] LOCK_RETRY_BACKOFF_MILLIS = { 150L, 400L, 900L };
 
     /*
+     * How many times a statistics reset will re-run when the updater re-creates what it just
+     * removed. Every repeat is driven by an observed non-empty store, never by a timer, so this only
+     * bounds a pathological case where the updater is fed faster than the reset can clear it.
+     */
+    private static final int STATISTICS_RESET_ATTEMPTS = 3;
+
+    /*
      * Derby: 40001 deadlock, 40XL1/40XL2 lock timeout.
      * PostgreSQL: 40001 serialization failure, 40P01 deadlock detected, 55P03 lock not available.
      */
@@ -131,6 +138,18 @@ public class TestUtils {
 
     private static Field pendingStatisticsField;
     private static boolean pendingStatisticsWarningLogged;
+
+    /**
+     * Reports a harness-level contention event. These go to stdout as well as the logger on purpose:
+     * log4j2 is not configured for donkey's ant test runs (nothing puts log4j2-test.properties on the
+     * classpath root, and no target sets log4j2.configurationFile), so a logger-only warning is
+     * invisible in a CI build log - which is the one place this needs to be searchable if statistics
+     * contention ever comes back. Only fires on actual contention, so it does not add build noise.
+     */
+    private static void warnContention(String message) {
+        logger.warn(message);
+        System.out.println("WARN " + message);
+    }
 
     /**
      * Closes HikariCP connection pools held by DonkeyConnectionPools.
@@ -1325,39 +1344,73 @@ public class TestUtils {
      *    the in-memory statistics we cleared still read zero.
      *
      * Both come from the same defect - nothing coordinates harness cleanup with the updater - so
-     * this first takes the updater's pending deltas for this channel away from it, then deletes
-     * with a retry for a flush that was already in flight, then verifies the rows really are gone.
+     * this takes the updater's pending deltas for this channel away from it, deletes with a retry
+     * for a flush that was already in flight, and then repeats until neither store has anything
+     * left for the channel.
+     *
+     * The loop is not defensive padding. After a successful flush the updater re-applies the
+     * *negated* snapshot to its pending map (DonkeyStatisticsUpdater.commit), so a flush that
+     * commits between the discard and the DELETE both re-creates the rows and repopulates the
+     * pending deltas - the latter after the discard already ran. Checking only the rows, or only
+     * checking once, therefore misses the case where the rows were deleted but a negated snapshot
+     * is still pending and would be inserted a tick later.
      */
     public static void deleteChannelStatistics(String channelId) throws SQLException {
         final long localChannelId = ChannelController.getInstance().getLocalChannelId(channelId);
         final String sql = "DELETE FROM D_MS" + localChannelId;
 
-        discardPendingStatistics(channelId);
-        executeWithLockRetry(sql, connection -> executeUpdate(connection, sql));
-
-        /*
-         * Deliberately after the DELETE, and deliberately not in a finally block: DonkeyDaoTests
-         * and ChannelControllerTests assert that the database and the in-memory statistics agree,
-         * so the two must be cleared together or not at all. Clearing memory on a path where the
-         * DELETE failed would leave memory at zero and the database stale, which surfaces as a
-         * confusing wrong-value assertion much later instead of the real error here.
-         */
-        Statistics statistics = ChannelController.getInstance().getStatistics();
-
-        if (statistics != null) {
-            statistics.remove(channelId);
-        }
-
-        /*
-         * If a flush committed between the discard and the DELETE, the rows are back. Repair once:
-         * the updater's pending deltas now hold the negated snapshot it re-applies after a
-         * successful commit, so they have to be discarded again along with the rows.
-         */
-        if (countStatisticsRows(localChannelId) > 0) {
-            logger.warn("Statistics rows for channel " + channelId + " were re-created by the Statistics Updater during cleanup; repairing (IRT-1788).");
+        for (int attempt = 1; attempt <= STATISTICS_RESET_ATTEMPTS; attempt++) {
             discardPendingStatistics(channelId);
             executeWithLockRetry(sql, connection -> executeUpdate(connection, sql));
+
+            /*
+             * Deliberately after the DELETE, and deliberately not in a finally block:
+             * DonkeyDaoTests and ChannelControllerTests assert that the database and the in-memory
+             * statistics agree, so the two must be cleared together or not at all. Clearing memory
+             * on a path where the DELETE failed would leave memory at zero and the database stale,
+             * which surfaces as a confusing wrong-value assertion much later instead of the real
+             * error here.
+             */
+            Statistics statistics = ChannelController.getInstance().getStatistics();
+
+            if (statistics != null) {
+                statistics.remove(channelId);
+            }
+
+            if (!hasPendingStatistics(channelId) && countStatisticsRows(localChannelId) == 0) {
+                return;
+            }
+
+            warnContention("Statistics for channel " + channelId + " were re-created by the Statistics Updater during cleanup (attempt " + attempt + " of " + STATISTICS_RESET_ATTEMPTS + "); repeating the reset (IRT-1788).");
         }
+
+        warnContention("Statistics for channel " + channelId + " were still being re-created by the Statistics Updater after " + STATISTICS_RESET_ATTEMPTS + " reset attempts (IRT-1788).");
+    }
+
+    /**
+     * Whether the Statistics Updater is holding a non-zero pending delta for this channel, which it
+     * would write to D_MS on its next tick. Reads a snapshot, so it does not disturb the map.
+     */
+    private static boolean hasPendingStatistics(String channelId) {
+        Statistics pendingStatistics = getPendingStatistics();
+
+        if (pendingStatistics == null) {
+            return false;
+        }
+
+        Map<Integer, Map<Status, Long>> channelStats = pendingStatistics.getStats().get(channelId);
+
+        if (channelStats != null) {
+            for (Map<Status, Long> connectorStats : channelStats.values()) {
+                for (Long value : connectorStats.values()) {
+                    if (value != null && value.longValue() != 0L) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -1373,11 +1426,25 @@ public class TestUtils {
      * on - the discarded deltas belong to traffic the test is throwing away.
      */
     private static void discardPendingStatistics(String channelId) {
+        Statistics pendingStatistics = getPendingStatistics();
+
+        if (pendingStatistics != null) {
+            // Scoped to this channel, not clear(), so multi-channel tests keep the rest.
+            pendingStatistics.remove(channelId);
+        }
+    }
+
+    /**
+     * The Statistics Updater's pending deltas, or null if they cannot be reached (engine not
+     * started, or the field was renamed - in which case one warning is logged and callers fall back
+     * to the previous, racier behavior).
+     */
+    private static Statistics getPendingStatistics() {
         DonkeyStatisticsUpdater updater = Donkey.getInstance().getStatisticsUpdater();
 
         if (updater == null) {
             // Engine not started yet, so there is no updater thread to race with.
-            return;
+            return null;
         }
 
         try {
@@ -1387,17 +1454,14 @@ public class TestUtils {
                 pendingStatisticsField = field;
             }
 
-            Statistics pendingStatistics = (Statistics) pendingStatisticsField.get(updater);
-
-            if (pendingStatistics != null) {
-                // Scoped to this channel, not clear(), so multi-channel tests keep the rest.
-                pendingStatistics.remove(channelId);
-            }
+            return (Statistics) pendingStatisticsField.get(updater);
         } catch (Exception e) {
             if (!pendingStatisticsWarningLogged) {
                 pendingStatisticsWarningLogged = true;
                 logger.warn("Unable to reach the Statistics Updater's pending statistics; channel statistics cleanup may race the updater thread (IRT-1788).", e);
             }
+
+            return null;
         }
     }
 
@@ -1465,7 +1529,7 @@ public class TestUtils {
                 connection.commit();
 
                 if (attempt > 1) {
-                    logger.warn("\"" + description + "\" succeeded on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + " after transient lock contention (IRT-1788).");
+                    warnContention("\"" + description + "\" succeeded on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + " after transient lock contention (IRT-1788).");
                 }
 
                 return value;
@@ -1476,7 +1540,9 @@ public class TestUtils {
                     throw e;
                 }
 
-                logger.warn("\"" + description + "\" hit a transient lock failure (SQLState=" + e.getSQLState() + ", errorCode=" + e.getErrorCode() + ") on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + "; retrying. This is normally contention with the Statistics Updater thread (IRT-1788).", e);
+                String failureMessage = "\"" + description + "\" hit a transient lock failure (SQLState=" + e.getSQLState() + ", errorCode=" + e.getErrorCode() + ") on attempt " + attempt + " of " + LOCK_RETRY_ATTEMPTS + "; retrying. This is normally contention with the Statistics Updater thread (IRT-1788).";
+                warnContention(failureMessage);
+                logger.debug(failureMessage, e);
             } finally {
                 // close(Connection) rolls back first, so a failed attempt leaves no open
                 // transaction on the pooled connection.


### PR DESCRIPTION
## Summary

Fixes the two flaky donkey tests tracked in IRT-1788. Both are test-harness defects — no product
code changes, no product impact. They matter because IRT-1539 made unit tests gate the build, so
they were reddening PRs for unrelated changes.

## 1. `ChannelTests.testContentRemoval` — Derby row-lock deadlock in setup

`TestUtils.deleteChannelStatistics` issued a raw `DELETE FROM D_MS<localChannelId>` while the
Statistics Updater thread (`DonkeyStatisticsUpdater`, 1000 ms tick, alive for the whole test class)
was issuing `UPDATE D_MS<localChannelId>` for the same channel. Derby detected the row-lock cycle
and rolled one of the two transactions back, failing whichever test was in setup.

Reading that code turned up a second failure vector on the same root cause — nothing coordinates
harness cleanup with the updater thread. A flush landing *after* the DELETE finds no rows to update,
so `JdbcDao.updateStatistics` falls through to `insertChannelStatistics` and re-creates the rows with
the previous test's counts, while the in-memory statistics the harness cleared still read zero. That
breaks the DB-vs-memory assertions in `DonkeyDaoTests` and `ChannelControllerTests`. Not observed in
the wild, but it is the same defect, so it is fixed here too.

`deleteChannelStatistics` now:

1. **takes the updater's pending deltas for that channel away from it** before deleting, so the
   updater has nothing to write back. `DonkeyStatisticsUpdater` keeps them in a private field and
   exposes no pause or flush, so the field is read reflectively and the public
   `Statistics.remove(channelId)` is called on it. Test-harness-only; if the field is ever renamed,
   the harness logs one warning and falls back to the previous behavior instead of breaking. Safe at
   every call site because all of them reset statistics *before* generating the traffic they assert
   on;
2. **retries the DELETE on a transient lock failure** — 4 attempts, 150/400/900 ms backoff (unequal
   and not multiples of the 1000 ms tick, so a retry cannot stay phase-locked to it). Exact SQLState
   allowlist (`40001`, `40XL1`, `40XL2`, `40P01`, `55P03`) plus a message fallback, walking both
   `getCause()` and `getNextException()`. Deliberately not a `"40"` prefix match: Derby's class 40
   also contains `40XC0` and `40XD*`, which are not contention. Every retry and repeat reports an
   IRT-1788 line **to stdout as well as the logger**, so the contention stays searchable in a CI
   build log rather than disappearing — log4j2 is not configured for donkey's ant test runs
   (`log4j2-test.properties` lands in `test_classes/conf`, not the classpath root, and no target sets
   `log4j2.configurationFile`), so a logger-only warning is invisible there;
3. **repeats until neither store holds anything for the channel**, bounded at three attempts. This
   is not padding: after a successful flush the updater re-applies the *negated* snapshot to its
   pending map, so a flush committing between the discard and the DELETE re-creates the rows *and*
   repopulates the pending deltas after the discard already ran. Deleting the rows then leaves a
   negated snapshot pending, which the next tick inserts as negative counts — and a single verifying
   `COUNT(*)` cannot see it, because at that moment the rows genuinely are gone. Each repeat is
   driven by observed state, never a timer, so the happy path is unchanged.

The in-memory `remove` stays *after* the DELETE and deliberately not in a `finally`: the database and
the in-memory statistics have to be cleared together or not at all, since tests assert they agree.
For the same reason `initChannel`'s `catch (DonkeyDaoException)` was **not** widened to
`catch (SQLException)` — that one-liner would turn a loud setup error into a confusing wrong-value
assertion 20 lines later.

## 2. `ConnectorTests.testPollConnector` — wall-clock equality assertion

The test slept 6800 ms and asserted exactly 7 polls. The ticket attributed the failures to the 7th
poll not finishing inside its 800 ms margin; that contributes, but the dominant mechanism is
different: Quartz anchors an interval trigger at **midnight**, not at `channel.start()`
(`TriggerFactory.createDailyInterval`), and `pollOnStart` is false, so polls fire on absolute
whole-second boundaries. A 6800 ms window contains 7 of those boundaries only when it starts at least
200 ms into a second — so ~20% of runs returned 6 on a completely idle machine. No margin tuning
fixes that.

The test now waits for the polls instead of timing them: a counting subclass of `TestPollConnector`
inside `ConnectorTests` counts completed polls on a `CountDownLatch` (the pattern already used by
`CountDownJob` in `PollConnectorJobTests`), and the test asserts that 7 polls completed within a
generous timeout, that they took at least `6 x pollingFrequency` — so a regression that ignores the
polling interval still fails — and that every poll produced exactly one processed message. The stale
javadoc (still describing 500 ms / 3250 ms) and the incorrect "polls fire at t=0, 1000, …" comment
are corrected.

No edit to `TestChannel.java`, so no overlap with #191.

## 3. Ignore per-database test report output

`**/junit-reports` and friends did not cover the `-postgres` / `-derby` / `-mysql` variants that
`ant test-run-<db>-db` writes, because gitignore patterns match whole path components. Added glob
siblings for all four report dirs, plus the temp `junit<n>.properties` /
`junitvmwatcher<n>.properties` files ant's forked `<junit>` task leaks into `donkey/` when a fork is
killed.

## Verification

A single green run proves nothing for either of these, so everything below is A/B with **prebuilt
class trees alternated run by run**, so machine-load drift hits both arms equally. No two suites ran
concurrently and nothing was recompiled mid-campaign (the harness verifies both).

**Statistics race** — scratch reproducer (not committed): traffic flows continuously while the reset
is hammered (deadlock arm), then a few messages are sent, statistics are reset, and `D_MS` is read
back past one updater tick (resurrection arm).

| | before | after |
|---|---|---|
| deadlocks | 4 / 12000 reset attempts | **0 / 12000** |
| stale statistics left after a reset | 48 / 48 resets | **0 / 48** |

The failures are byte-for-byte the ticket's exception — `SQLTransactionRollbackException`, cycle
`ROW, D_MS1, (1,7)`, `DELETE FROM D_MS1` waiting on the updater's `UPDATE D_MS1 SET RECEIVED = CASE
WHEN ...`.

**Poll test** — interleaved A/B on PostgreSQL, 8 pairs: **8/8 failed before** with
`expected:<7> but was:<6>`, **8/8 passed after**, each reaching 7 polls in ~8.2 s (so the
`>= 6 x frequency` floor passes with margin rather than by luck). Note the rate here was 100%, not
the 1-in-4 in the ticket — same mechanism, this machine simply lands in the losing phase window
consistently.

**`ChannelTests` at class level** — 10 pairs interleaved with Derby lock-timeout amplification
(`-Dderby.locks.waitTimeout=1`): 10/10 green in both arms, so this arm produced **no signal** and is
reported as inconclusive rather than as evidence. Per-run duration was unchanged (25-27 s both arms),
which does confirm the fix costs nothing.

**Retry and repeat layers, exercised deliberately** — the reproducer reports resets that *fail*, and
a successful retry throws nothing, so it cannot distinguish "no contention" from "retried and
recovered". Both paths were therefore driven directly. With a competing transaction holding row locks
on `D_MS`:
retry-then-succeed under a 1.5 s blocker (passed, 1283 ms), bounded give-up that throws rather than
silently continuing when the blocker outlasts the retry budget (passed), and 9 classification cases
including a `DonkeyDaoException`-wrapped cause, a `getNextException()`-only chain, and a
self-referential chain (all passed). With a thread continuously repopulating the updater, the repeat
loop fires three times and then gives up with a warning in 20 ms, without throwing or hanging.

Those checks caught two real defects in earlier versions of this change, both fixed here: `ArrayDeque`
rejects nulls, so an unchained non-lock `SQLException` produced an NPE instead of a clean
classification; and the contention warnings were logger-only, i.e. invisible in exactly the CI logs
the PR claimed they would be searchable in.

**Full suites**, one at a time: `ant test-run` (Derby, what CI runs) and `ant test-run-postgres-db` —
**151 tests, 0 failures, 0 errors** on both, re-run after the review fixes, with no contention events
reported during either run. No tests added or removed. Both databases clean afterwards, no stray
containers or processes.

## Residual risk

The resurrection window shrinks from up to a full updater tick (~1000 ms) to the microseconds between
the updater's `dao.commit()` returning and its negated-snapshot re-apply — the only interleaving where
the harness can observe both stores empty while a flush is still pending. Closing that completely
needs a real quiesce/`flushNow` API on `DonkeyStatisticsUpdater`: product code, which this PR
deliberately avoids per the ticket's framing. The reflective field access is the price of keeping the
fix test-side; it is guarded and degrades to a warning if the field is ever renamed.

Review note: the poll test's elapsed-time assertion bounds the polling frequency from below only — it
catches polls firing faster than configured or the interval being ignored, not polls firing slower. An
upper bound is deliberately omitted: `PollConnectorJob` silently drops a fire whose predecessor is
still running, so any bound loose enough to be stable on a loaded machine would be too loose to catch
a real regression, and it would reintroduce the wall-clock flakiness this ticket is about.
