### PR TITLE
IRT-1786, IRT-1791: check stored passwords against policy at login

### DIFF
--- a/client/src/com/mirth/connect/client/ui/ChangePasswordDialog.java
+++ b/client/src/com/mirth/connect/client/ui/ChangePasswordDialog.java
@@ -15,10 +15,16 @@ import java.awt.Point;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 
-import javax.swing.JDialog;
+import java.util.List;
 
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import com.mirth.connect.client.core.Client;
+import com.mirth.connect.client.core.ClientException;
 import com.mirth.connect.client.ui.util.DisplayUtil;
 import com.mirth.connect.model.User;
 
@@ -26,11 +32,32 @@ public class ChangePasswordDialog extends MirthDialog {
 
     private Frame parent;
     private User currentUser;
+    private Client client;
+    private boolean result;
 
+    /**
+     * Shows the dialog over the main Administrator window, updating the password through it.
+     */
     public ChangePasswordDialog(User currentUser, String message) {
-        super(PlatformUI.MIRTH_FRAME);
+        this(PlatformUI.MIRTH_FRAME, null, currentUser, message);
+    }
+
+    /**
+     * Shows the dialog before the main Administrator window exists, talking to the server directly.
+     * <p>
+     * A password serving out a grace period may be confined by the server to password-change
+     * operations, so the change has to happen before the Administrator starts issuing requests it
+     * is not allowed to make. Use {@link #getResult()} to find out whether the change was made.
+     */
+    public ChangePasswordDialog(Client client, User currentUser, String message) {
+        this(null, client, currentUser, message);
+    }
+
+    private ChangePasswordDialog(Frame parent, Client client, User currentUser, String message) {
+        super(parent);
         this.currentUser = currentUser;
-        this.parent = PlatformUI.MIRTH_FRAME;
+        this.parent = parent;
+        this.client = client;
         initComponents();
         DisplayUtil.setResizable(this, false);
 
@@ -55,17 +82,66 @@ public class ChangePasswordDialog extends MirthDialog {
         });
 
         pack();
-        Dimension dlgSize = getPreferredSize();
-        Dimension frmSize = parent.getSize();
-        Point loc = parent.getLocation();
 
-        if ((frmSize.width == 0 && frmSize.height == 0) || (loc.x == 0 && loc.y == 0)) {
+        if (parent == null) {
             setLocationRelativeTo(null);
         } else {
-            setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, (frmSize.height - dlgSize.height) / 2 + loc.y);
+            Dimension dlgSize = getPreferredSize();
+            Dimension frmSize = parent.getSize();
+            Point loc = parent.getLocation();
+
+            if ((frmSize.width == 0 && frmSize.height == 0) || (loc.x == 0 && loc.y == 0)) {
+                setLocationRelativeTo(null);
+            } else {
+                setLocation((frmSize.width - dlgSize.width) / 2 + loc.x, (frmSize.height - dlgSize.height) / 2 + loc.y);
+            }
         }
 
         setVisible(true);
+    }
+
+    /**
+     * Whether the password was actually changed. False if the user dismissed the dialog, in which
+     * case a caller gating login on the change should abort it.
+     */
+    public boolean getResult() {
+        return result;
+    }
+
+    /**
+     * Applies the new password, returning true if the server accepted it. Requirement violations are
+     * reported in the same format the Administrator uses elsewhere.
+     */
+    private boolean updatePassword(String newPassword) {
+        if (parent != null) {
+            return parent.checkOrUpdateUserPassword(this, currentUser, newPassword);
+        }
+
+        try {
+            List<String> responses = client.updateUserPassword(currentUser.getId(), newPassword);
+
+            if (CollectionUtils.isNotEmpty(responses)) {
+                StringBuilder builder = new StringBuilder("Your password is not valid. Please fix the following:\n");
+                for (String response : responses) {
+                    builder.append(" - ").append(response).append("\n");
+                }
+                alert(builder.toString());
+                return false;
+            }
+        } catch (ClientException e) {
+            alert("The password could not be changed: " + e.getMessage());
+            return false;
+        }
+
+        return true;
+    }
+
+    private void alert(String message) {
+        if (parent != null) {
+            parent.alertError(this, message);
+        } else {
+            JOptionPane.showMessageDialog(this, message, "Error", JOptionPane.ERROR_MESSAGE);
+        }
     }
 
     public void setFinishButtonEnabled(boolean enabled) {
@@ -174,7 +250,7 @@ public class ChangePasswordDialog extends MirthDialog {
         passwordTextArea.setFont(new java.awt.Font("Tahoma", 0, 11)); // NOI18N
         passwordTextArea.setLineWrap(true);
         passwordTextArea.setRows(2);
-        passwordTextArea.setText("Your password has expired. You are required to change your password in the next 14 days and 23 hours.");
+        passwordTextArea.setText("");
         passwordTextArea.setWrapStyleWord(true);
         passwordTextArea.setEnabled(false);
         passwordPane.setViewportView(passwordTextArea);
@@ -254,12 +330,13 @@ public class ChangePasswordDialog extends MirthDialog {
         password.requestFocusInWindow();
 
         if (!String.valueOf(password.getPassword()).equals(String.valueOf(confirmPassword.getPassword()))) {
-            parent.alertError(this, "The passwords you entered do not match.");
+            alert("The passwords you entered do not match.");
             return;
-        } else if (!parent.checkOrUpdateUserPassword(this, currentUser, String.valueOf(password.getPassword()))) {
+        } else if (!updatePassword(String.valueOf(password.getPassword()))) {
             return;
         }
 
+        result = true;
         this.dispose();
     }//GEN-LAST:event_finishButtonActionPerformed
 
@@ -272,6 +349,7 @@ public class ChangePasswordDialog extends MirthDialog {
     }//GEN-LAST:event_confirmPasswordKeyReleased
 
     private void cancelButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cancelButtonActionPerformed
+        result = false;
         this.dispose();
     }//GEN-LAST:event_cancelButtonActionPerformed
 

--- a/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
+++ b/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
@@ -44,6 +44,7 @@ public class FirstLoginDialog extends javax.swing.JDialog implements com.mirth.c
 
     private Frame parent;
     private boolean result = false;
+    private boolean passwordRequired;
     private static Preferences preferences;
 
     /** Creates new form UserDialog */
@@ -59,6 +60,7 @@ public class FirstLoginDialog extends javax.swing.JDialog implements com.mirth.c
     public FirstLoginDialog(User currentUser, boolean passwordRequired) {
         super(com.mirth.connect.client.ui.PlatformUI.MIRTH_FRAME);
         this.parent = com.mirth.connect.client.ui.PlatformUI.MIRTH_FRAME;
+        this.passwordRequired = passwordRequired;
         initComponents();
         DisplayUtil.setResizable(this, false);
         finishButton.setEnabled(false);
@@ -335,7 +337,8 @@ public class FirstLoginDialog extends javax.swing.JDialog implements com.mirth.c
         	userConsentCheckBox.setSelected(false);
         	userConsentCheckBox.setEnabled(false);
         }
-        userEditPanel.setRequiredFields(allRequired, true);
+        // Keep honoring an already-completed password change, rather than asking for one again
+        userEditPanel.setRequiredFields(allRequired, passwordRequired);
     }//GEN-LAST:event_registerCheckBoxActionPerformed
     
     public boolean getResult() {

--- a/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
+++ b/client/src/com/mirth/connect/client/ui/FirstLoginDialog.java
@@ -48,6 +48,15 @@ public class FirstLoginDialog extends javax.swing.JDialog implements com.mirth.c
 
     /** Creates new form UserDialog */
     public FirstLoginDialog(User currentUser) {
+        this(currentUser, true);
+    }
+
+    /**
+     * @param passwordRequired
+     *            false when the password has already been changed earlier in the login, so that the
+     *            user is not asked for a new one twice.
+     */
+    public FirstLoginDialog(User currentUser, boolean passwordRequired) {
         super(com.mirth.connect.client.ui.PlatformUI.MIRTH_FRAME);
         this.parent = com.mirth.connect.client.ui.PlatformUI.MIRTH_FRAME;
         initComponents();
@@ -55,7 +64,7 @@ public class FirstLoginDialog extends javax.swing.JDialog implements com.mirth.c
         finishButton.setEnabled(false);
 
         userEditPanel.setUser(this, currentUser);
-        userEditPanel.setRequiredFields(false, true); 
+        userEditPanel.setRequiredFields(false, passwordRequired);
         if (currentUser.getId() == 1) {
             registerCheckBox.setVisible(false);
         }

--- a/client/src/com/mirth/connect/client/ui/LoginPanel.java
+++ b/client/src/com/mirth/connect/client/ui/LoginPanel.java
@@ -564,6 +564,31 @@ public class LoginPanel extends AbstractLoginPanel {
 
                 com.mirth.connect.client.ui.PlatformUI.USER_NAME = StringUtils.defaultString(loginStatus.getUpdatedUsername(), username.getText());
                 setStatus("Authenticated...");
+
+                /*
+                 * Deal with a grace period before the Administrator starts up, not after. The
+                 * server can be configured to confine a grace-period login to password-change
+                 * operations, in which case every request the Administrator makes while loading
+                 * would be rejected before the user ever saw the prompt.
+                 */
+                boolean passwordChanged = false;
+                if (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
+                    User graceUser = client.getCurrentUser();
+                    ChangePasswordDialog changePasswordDialog = new ChangePasswordDialog(client, graceUser, loginStatus.getMessage());
+
+                    if (!changePasswordDialog.getResult()) {
+                        // Dismissed without changing it, so the login cannot proceed
+                        try {
+                            client.logout();
+                        } catch (ClientException e) {
+                            // Already failing the login; nothing useful to do with this
+                        }
+                        return false;
+                    }
+
+                    passwordChanged = true;
+                }
+
                 new Mirth(client);
                 setVisible(false);
 
@@ -601,13 +626,12 @@ public class LoginPanel extends AbstractLoginPanel {
                             	currentUser.setDescription(info[10]);
                         	}
                     	}
-                        com.mirth.connect.client.ui.FirstLoginDialog firstLoginDialog = new com.mirth.connect.client.ui.FirstLoginDialog(currentUser);
+                        // The password is already compliant if it was changed above, so don't ask twice
+                        com.mirth.connect.client.ui.FirstLoginDialog firstLoginDialog = new com.mirth.connect.client.ui.FirstLoginDialog(currentUser, !passwordChanged);
                         // if leaving the first login dialog without saving
                         if (!firstLoginDialog.getResult()) {
                         	return false;
                         }
-                    } else if (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
-                        new com.mirth.connect.client.ui.ChangePasswordDialog(currentUser, loginStatus.getMessage());
                     }
 
                     // Check for new notifications from update server if enabled

--- a/client/src/com/mirth/connect/client/ui/MirthDialog.java
+++ b/client/src/com/mirth/connect/client/ui/MirthDialog.java
@@ -33,15 +33,24 @@ public abstract class MirthDialog extends JDialog {
         registerCloseAction();
     }
 
+    /*
+     * PlatformUI.MIRTH_FRAME is not assigned until the Administrator window is built, so a dialog
+     * shown before that point — the forced password change during login — would fail here rather
+     * than display. There is nothing to suppress saving on when no window exists yet.
+     */
     @Override
     public void setVisible(boolean b) {
-        PlatformUI.MIRTH_FRAME.setCanSave(!b);
+        if (PlatformUI.MIRTH_FRAME != null) {
+            PlatformUI.MIRTH_FRAME.setCanSave(!b);
+        }
         super.setVisible(b);
     }
 
     @Override
     public void dispose() {
-        PlatformUI.MIRTH_FRAME.setCanSave(true);
+        if (PlatformUI.MIRTH_FRAME != null) {
+            PlatformUI.MIRTH_FRAME.setCanSave(true);
+        }
         super.dispose();
     }
 

--- a/client/test/com/mirth/connect/client/ui/MirthDialogNoFrameTest.java
+++ b/client/test/com/mirth/connect/client/ui/MirthDialogNoFrameTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.client.ui;
+
+import static org.junit.Assert.assertFalse;
+
+import java.awt.GraphicsEnvironment;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * MirthDialog reaches for PlatformUI.MIRTH_FRAME on show and on dispose, but that field is not
+ * assigned until the Administrator window is built. The forced password change runs before that
+ * point, so a dialog has to survive without one. See IRT-1791.
+ */
+public class MirthDialogNoFrameTest {
+
+    private Frame originalFrame;
+
+    @Before
+    public void setUp() {
+        Assume.assumeFalse("Needs a display to construct a dialog", GraphicsEnvironment.isHeadless());
+
+        originalFrame = PlatformUI.MIRTH_FRAME;
+        PlatformUI.MIRTH_FRAME = null;
+    }
+
+    @After
+    public void tearDown() {
+        PlatformUI.MIRTH_FRAME = originalFrame;
+    }
+
+    /**
+     * Fails with a NullPointerException if the null guards are removed, which is what a fresh
+     * install hitting the change-password prompt would have seen.
+     */
+    @Test
+    public void dialogCanBeShownAndDisposedWithoutTheAdministratorWindow() {
+        MirthDialog dialog = new MirthDialog(null, "test", false) {
+        };
+
+        // setVisible(true) would block on a modal dialog, and false exercises the same dereference
+        dialog.setVisible(false);
+        dialog.dispose();
+
+        assertFalse(dialog.isVisible());
+    }
+}

--- a/command/src/com/mirth/connect/cli/CommandLineInterface.java
+++ b/command/src/com/mirth/connect/cli/CommandLineInterface.java
@@ -187,9 +187,18 @@ public class CommandLineInterface {
 
             LoginStatus loginStatus = client.login(user, password);
 
-            if (loginStatus.getStatus() != LoginStatus.Status.SUCCESS) {
+            if (loginStatus.getStatus() != LoginStatus.Status.SUCCESS && loginStatus.getStatus() != LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
                 error("Could not login to server.", null);
                 return;
+            }
+
+            /*
+             * The login succeeded but the password is serving out a grace period, either because it
+             * expired or because it no longer meets the password requirements. Say so rather than
+             * failing, which would misreport it as a bad credential.
+             */
+            if (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
+                out.println("Warning: " + loginStatus.getMessage());
             }
 
             String serverVersion = client.getVersion();

--- a/server/conf/mirth.properties
+++ b/server/conf/mirth.properties
@@ -23,6 +23,21 @@ password.reuselimit = 0
 # Warning: Changing allowusernameenumeration to true could allow user enumeration by an attacker
 password.allowusernameenumeration = false
 
+# Evaluate an already-stored password against the requirements above at login, and prompt the user
+# to change it when it no longer passes. Without this, the requirements apply only when a password
+# is set, so any password predating a policy change keeps working indefinitely. Login still
+# succeeds, so API and integration clients are unaffected.
+password.enforceatlogin = true
+
+# Restrict a session whose password failed the check above to password-change operations only.
+# Off by default because it is a breaking change for automation: any account whose stored password
+# does not meet the requirements will receive HTTP 403 on every other operation until its password
+# is rotated, and stored passwords are hashed, so there is no way to identify the affected accounts
+# before they log in. Enable it only after reviewing the login events raised by enforceatlogin.
+# Note: the legacy webadmin war does not prompt for a password change, so its users would see
+# failures with no explanation.
+password.restrictgracesessions = false
+
 # Only used for migration purposes, do not modify
 version = 26.6.0
 

--- a/server/src/com/mirth/connect/model/PasswordRequirements.java
+++ b/server/src/com/mirth/connect/model/PasswordRequirements.java
@@ -30,6 +30,8 @@ public class PasswordRequirements implements Serializable {
     private int reusePeriod;
     private int reuseLimit;
     private boolean allowUsernameEnumeration;
+    private boolean enforceAtLogin;
+    private boolean restrictGraceSessions;
 
     public PasswordRequirements() {
         this.minLength = 0;
@@ -44,6 +46,8 @@ public class PasswordRequirements implements Serializable {
         this.reusePeriod = 0;
         this.reuseLimit = 0;
         this.allowUsernameEnumeration = false;
+        this.enforceAtLogin = true;
+        this.restrictGraceSessions = false;
     }
     /**
      * @deprecated Use {@link #PasswordRequirements(int, int, int, int, int, int, int, int, int, int, int, boolean)} instead.
@@ -66,6 +70,8 @@ public class PasswordRequirements implements Serializable {
         this.reusePeriod = reusePeriod;
         this.reuseLimit = reuseLimit;
         this.allowUsernameEnumeration = allowUsernameEnumeration;
+        this.enforceAtLogin = true;
+        this.restrictGraceSessions = false;
     }
 
     public int getMinLength() {
@@ -163,5 +169,32 @@ public class PasswordRequirements implements Serializable {
 
     public void setAllowUsernameEnumeration(boolean allowUsernameEnumeration) {
         this.allowUsernameEnumeration = allowUsernameEnumeration;
+    }
+
+    /**
+     * Whether an already-stored password is evaluated against these requirements at login. Policy
+     * is otherwise only applied when a password is set, so passwords predating a policy change are
+     * never re-examined.
+     */
+    public boolean isEnforceAtLogin() {
+        return enforceAtLogin;
+    }
+
+    public void setEnforceAtLogin(boolean enforceAtLogin) {
+        this.enforceAtLogin = enforceAtLogin;
+    }
+
+    /**
+     * Whether a grace-period session is restricted to password-change operations. Off by default:
+     * turning it on will reject requests from any automation account whose password does not meet
+     * the current requirements, and there is no way to identify those accounts in advance because
+     * stored passwords are hashed.
+     */
+    public boolean isRestrictGraceSessions() {
+        return restrictGraceSessions;
+    }
+
+    public void setRestrictGraceSessions(boolean restrictGraceSessions) {
+        this.restrictGraceSessions = restrictGraceSessions;
     }
 }

--- a/server/src/com/mirth/connect/server/api/MirthServlet.java
+++ b/server/src/com/mirth/connect/server/api/MirthServlet.java
@@ -57,16 +57,31 @@ public abstract class MirthServlet {
     protected static final String SESSION_GRACE_RESTRICTED = "graceRestricted";
 
     /**
-     * Operations a grace-restricted login may still perform. These are the ones needed to complete
-     * the password change that lifts the restriction: the client has to identify itself before it
-     * can change its own password, and it needs the requirements to explain a rejection. The list
-     * only narrows access — an operation named here still goes through the normal permission check.
+     * Operations a grace-restricted login may still perform regardless of who they are aimed at.
+     * These are the ones needed to complete the password change that lifts the restriction: the
+     * client has to identify itself before it can change its own password, and it needs the
+     * requirements to explain a rejection. None of them name another user — checkUserPassword only
+     * takes a plaintext string — so none of them need scoping; the change itself is scoped through
+     * {@link #GRACE_PERIOD_SELF_ONLY_OPERATIONS}. The list only narrows access — an operation named
+     * here still goes through the normal permission check.
      * <p>
      * Logging out is included because it only destroys the session; refusing it would leave a user
      * who declines the change with no way to end the session they cannot otherwise use. Note the
      * logout endpoints call isUserAuthorized purely to audit, and ignore the answer.
      */
-    private static final Set<String> GRACE_PERIOD_ALLOWED_OPERATIONS = new HashSet<String>(Arrays.asList("updateUserPassword", "checkUserPassword", "getPasswordRequirements", "getCurrentUser", "logout", "inactivityLogout"));
+    private static final Set<String> GRACE_PERIOD_ALLOWED_OPERATIONS = new HashSet<String>(Arrays.asList("checkUserPassword", "getPasswordRequirements", "getCurrentUser", "logout", "inactivityLogout"));
+
+    /**
+     * Operations a grace-restricted login may perform, but only against its own account. Changing
+     * a password is the one thing the restriction exists to permit, yet nothing in the operation
+     * itself limits it to the caller — so allowing it by name alone let a confined login reset
+     * another user's password and log back in as that user with no restriction at all (IRT-1798).
+     * <p>
+     * The target user ID reaches this class through
+     * {@link #checkUserAuthorized(Integer, boolean)}. If it is not known the operation is refused,
+     * since a request that cannot prove it targets the caller is exactly the one to reject.
+     */
+    private static final Set<String> GRACE_PERIOD_SELF_ONLY_OPERATIONS = new HashSet<String>(Arrays.asList("updateUserPassword"));
 
     private static final String GRACE_RESTRICTED_MESSAGE = "Your password does not meet the password requirements. Until it is changed, this login may only be used to change it.";
 
@@ -90,6 +105,7 @@ public abstract class MirthServlet {
     private boolean bypassUser;
     private int currentUserId;
     private boolean graceRestricted;
+    private Integer authorizedUserId;
 
     public MirthServlet(HttpServletRequest request, SecurityContext sc) {
         this(request, null, sc);
@@ -262,6 +278,10 @@ public abstract class MirthServlet {
     }
 
     public void checkUserAuthorized(Integer userId, boolean auditCurrentUser) {
+        // Recorded before either branch runs so the grace period check can scope the operations in
+        // GRACE_PERIOD_SELF_ONLY_OPERATIONS to the user this request is actually aimed at.
+        authorizedUserId = userId;
+
         // At first glance this logic looks unnecessary, but it is important to note
         // isUserAuthorized() will trigger an audit, so having it first in
         // the conditional means it will always trigger the audit whereas
@@ -334,7 +354,17 @@ public abstract class MirthServlet {
             return false;
         }
 
-        return !GRACE_PERIOD_ALLOWED_OPERATIONS.contains(operation.getName());
+        String operationName = operation.getName();
+
+        if (GRACE_PERIOD_ALLOWED_OPERATIONS.contains(operationName)) {
+            return false;
+        }
+
+        if (GRACE_PERIOD_SELF_ONLY_OPERATIONS.contains(operationName)) {
+            return authorizedUserId == null || !isCurrentUser(authorizedUserId);
+        }
+
+        return true;
     }
 
     protected void checkUserAuthorizedForExtension(String extensionName) {

--- a/server/src/com/mirth/connect/server/api/MirthServlet.java
+++ b/server/src/com/mirth/connect/server/api/MirthServlet.java
@@ -61,8 +61,12 @@ public abstract class MirthServlet {
      * the password change that lifts the restriction: the client has to identify itself before it
      * can change its own password, and it needs the requirements to explain a rejection. The list
      * only narrows access — an operation named here still goes through the normal permission check.
+     * <p>
+     * Logging out is included because it only destroys the session; refusing it would leave a user
+     * who declines the change with no way to end the session they cannot otherwise use. Note the
+     * logout endpoints call isUserAuthorized purely to audit, and ignore the answer.
      */
-    private static final Set<String> GRACE_PERIOD_ALLOWED_OPERATIONS = new HashSet<String>(Arrays.asList("updateUserPassword", "checkUserPassword", "getPasswordRequirements", "getCurrentUser"));
+    private static final Set<String> GRACE_PERIOD_ALLOWED_OPERATIONS = new HashSet<String>(Arrays.asList("updateUserPassword", "checkUserPassword", "getPasswordRequirements", "getCurrentUser", "logout", "inactivityLogout"));
 
     private static final String GRACE_RESTRICTED_MESSAGE = "Your password does not meet the password requirements. Until it is changed, this login may only be used to change it.";
 

--- a/server/src/com/mirth/connect/server/api/MirthServlet.java
+++ b/server/src/com/mirth/connect/server/api/MirthServlet.java
@@ -12,6 +12,7 @@ package com.mirth.connect.server.api;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -27,6 +28,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.SecurityContext;
 
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.mirth.connect.client.core.ControllerException;
@@ -36,6 +38,7 @@ import com.mirth.connect.client.core.api.MirthApiException;
 import com.mirth.connect.model.Channel;
 import com.mirth.connect.model.ChannelSummary;
 import com.mirth.connect.model.LoginStatus;
+import com.mirth.connect.model.PasswordRequirements;
 import com.mirth.connect.model.ServerEvent.Outcome;
 import com.mirth.connect.model.ServerEventContext;
 import com.mirth.connect.model.User;
@@ -51,6 +54,17 @@ public abstract class MirthServlet {
 
     protected static final String SESSION_USER = "user";
     protected static final String SESSION_AUTHORIZED = "authorized";
+    protected static final String SESSION_GRACE_RESTRICTED = "graceRestricted";
+
+    /**
+     * Operations a grace-restricted login may still perform. These are the ones needed to complete
+     * the password change that lifts the restriction: the client has to identify itself before it
+     * can change its own password, and it needs the requirements to explain a rejection. The list
+     * only narrows access — an operation named here still goes through the normal permission check.
+     */
+    private static final Set<String> GRACE_PERIOD_ALLOWED_OPERATIONS = new HashSet<String>(Arrays.asList("updateUserPassword", "checkUserPassword", "getPasswordRequirements", "getCurrentUser"));
+
+    private static final String GRACE_RESTRICTED_MESSAGE = "Your password does not meet the password requirements. Until it is changed, this login may only be used to change it.";
 
     protected HttpServletRequest request;
     protected ContainerRequestContext containerRequestContext;
@@ -71,6 +85,7 @@ public abstract class MirthServlet {
     private String extensionName;
     private boolean bypassUser;
     private int currentUserId;
+    private boolean graceRestricted;
 
     public MirthServlet(HttpServletRequest request, SecurityContext sc) {
         this(request, null, sc);
@@ -140,6 +155,7 @@ public abstract class MirthServlet {
 
         if (isUserLoggedIn()) {
             currentUserId = Integer.parseInt(request.getSession().getAttribute(SESSION_USER).toString());
+            graceRestricted = BooleanUtils.isTrue((Boolean) request.getSession().getAttribute(SESSION_GRACE_RESTRICTED));
             setContext();
             validLogin = true;
         } else {
@@ -179,6 +195,8 @@ public abstract class MirthServlet {
 
                                     if (user != null) {
                                         currentUserId = user.getId();
+                                        // No session here, so this applies to this request only
+                                        graceRestricted = (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD);
                                         setContext();
                                         validLogin = true;
                                     } else {
@@ -281,11 +299,38 @@ public abstract class MirthServlet {
                 }
                 return true;
             } else {
+                if (isDeniedByGraceRestriction()) {
+                    if (audit) {
+                        auditAuthorizationRequest(Outcome.FAILURE);
+                    }
+                    throw new MirthApiException(Response.status(Status.FORBIDDEN).entity(GRACE_RESTRICTED_MESSAGE).build());
+                }
+
                 return authorizationController.isUserAuthorized(getCurrentUserId(), operation, parameterMap, getRequestIpAddress(), audit);
             }
         } catch (ControllerException e) {
             throw new MirthApiException(e);
         }
+    }
+
+    /**
+     * Whether this request should be refused because the login it came from is serving out a
+     * password grace period. Off unless the server enables password.restrictgracesessions, since
+     * turning it on rejects any automation account whose stored password no longer meets the
+     * password requirements.
+     */
+    private boolean isDeniedByGraceRestriction() {
+        if (!graceRestricted) {
+            return false;
+        }
+
+        PasswordRequirements passwordRequirements = configurationController.getPasswordRequirements();
+
+        if (passwordRequirements == null || !passwordRequirements.isRestrictGraceSessions()) {
+            return false;
+        }
+
+        return !GRACE_PERIOD_ALLOWED_OPERATIONS.contains(operation.getName());
     }
 
     protected void checkUserAuthorizedForExtension(String extensionName) {
@@ -312,6 +357,13 @@ public abstract class MirthServlet {
                 }
                 return true;
             } else {
+                if (isDeniedByGraceRestriction()) {
+                    if (audit) {
+                        auditAuthorizationRequest(Outcome.FAILURE, extensionOperation);
+                    }
+                    throw new MirthApiException(Response.status(Status.FORBIDDEN).entity(GRACE_RESTRICTED_MESSAGE).build());
+                }
+
                 return authorizationController.isUserAuthorized(getCurrentUserId(), extensionOperation, parameterMap, getRequestIpAddress(), audit);
             }
         } catch (ControllerException e) {

--- a/server/src/com/mirth/connect/server/api/servlets/UserServlet.java
+++ b/server/src/com/mirth/connect/server/api/servlets/UserServlet.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.mirth.connect.client.core.ClientException;
@@ -115,6 +116,17 @@ public class UserServlet extends MirthServlet implements UserServletInterface {
                         session.setAttribute(SESSION_USER, validUser.getId());
                         session.setAttribute(SESSION_AUTHORIZED, true);
 
+                        /*
+                         * A grace period means the stored password no longer meets the password
+                         * requirements (or has expired). Mark the session so MirthServlet can
+                         * confine it to changing that password, if the server is configured to.
+                         */
+                        if (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
+                            session.setAttribute(SESSION_GRACE_RESTRICTED, true);
+                        } else {
+                            session.removeAttribute(SESSION_GRACE_RESTRICTED);
+                        }
+
                         // set the user status to logged in in the database
                         userController.loginUser(validUser);
 
@@ -139,6 +151,30 @@ public class UserServlet extends MirthServlet implements UserServletInterface {
                 event.setAttributes(attributes);
 
                 eventController.dispatchEvent(event);
+
+                /*
+                 * Raise a distinct event when the login was allowed but the password no longer
+                 * meets requirements. Because stored passwords are hashed there is no way to audit
+                 * which accounts are affected, so this is the only way an administrator can find
+                 * them. It is dispatched here rather than in authorizeUser because that method also
+                 * runs on every Basic auth REST request, which would flood the event table.
+                 */
+                if (loginStatus.getStatus() == LoginStatus.Status.SUCCESS_GRACE_PERIOD) {
+                    ServerEvent passwordEvent = new ServerEvent(configurationController.getServerId(), "Password does not meet requirements");
+                    if (validUser != null) {
+                        passwordEvent.setUserId(validUser.getId());
+                    }
+                    passwordEvent.setIpAddress(getRequestIpAddress());
+                    passwordEvent.setLevel(Level.INFORMATION);
+                    passwordEvent.setOutcome(Outcome.SUCCESS);
+
+                    Map<String, String> passwordAttributes = new HashMap<String, String>();
+                    passwordAttributes.put("username", username);
+                    passwordAttributes.put("details", loginStatus.getMessage());
+                    passwordEvent.setAttributes(passwordAttributes);
+
+                    eventController.dispatchEvent(passwordEvent);
+                }
             }
         } catch (Exception e) {
             throw new MirthApiException(e);
@@ -293,7 +329,19 @@ public class UserServlet extends MirthServlet implements UserServletInterface {
     @CheckAuthorizedUserId
     public List<String> updateUserPassword(Integer userId, String plainPassword) {
         try {
-            return userController.checkOrUpdateUserPassword(userId, plainPassword);
+            List<String> responses = userController.checkOrUpdateUserPassword(userId, plainPassword);
+
+            /*
+             * The password now meets requirements, so lift any restriction placed on this session
+             * at login. The database grace period is cleared by checkOrUpdateUserPassword, but the
+             * session flag is separate state and would otherwise persist for the life of the
+             * session, leaving the user unable to do anything after a successful change.
+             */
+            if (CollectionUtils.isEmpty(responses) && isCurrentUser(userId)) {
+                request.getSession().removeAttribute(SESSION_GRACE_RESTRICTED);
+            }
+
+            return responses;
         } catch (ControllerException e) {
             throw new MirthApiException(e);
         }

--- a/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
+++ b/server/src/com/mirth/connect/server/controllers/DefaultUserController.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import com.mirth.commons.encryption.Digester;
 import com.mirth.connect.client.core.ControllerException;
 import com.mirth.connect.model.Credentials;
+import com.mirth.connect.model.ExtendedLoginStatus;
 import com.mirth.connect.model.LoginStatus;
 import com.mirth.connect.model.LoginStatus.Status;
 import com.mirth.connect.model.LoginStrike;
@@ -378,11 +379,25 @@ public class DefaultUserController extends UserController {
 
                 // If nothing failed (loginStatus != null), set SUCCESS now
                 if (loginStatus == null) {
-                    loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS, "");
+                    /*
+                     * Password requirements are otherwise only applied when a password is set, so a
+                     * password predating a policy change is never re-examined. Login is the one
+                     * point where the server holds the plaintext and can evaluate it. See IRT-1791.
+                     */
+                    List<String> violations = null;
+                    if (passwordRequirements.isEnforceAtLogin()) {
+                        violations = getStoredPasswordViolations(plainPassword, passwordRequirements);
+                    }
 
-                    // Clear the user's grace period if one exists
-                    if (validUser.getGracePeriodStart() != null) {
-                        SqlConfig.getInstance().getSqlSessionManager().update("User.clearGracePeriod", validUser.getId());
+                    if (CollectionUtils.isNotEmpty(violations)) {
+                        loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, buildRequirementsMessage(violations));
+                    } else {
+                        loginStatus = new LoginStatus(LoginStatus.Status.SUCCESS, "");
+
+                        // Clear the user's grace period if one exists
+                        if (validUser.getGracePeriodStart() != null) {
+                            SqlConfig.getInstance().getSqlSessionManager().update("User.clearGracePeriod", validUser.getId());
+                        }
                     }
                 }
             } else {
@@ -410,6 +425,35 @@ public class DefaultUserController extends UserController {
         } finally {
             StatementLock.getInstance(VACUUM_LOCK_PERSON_STATEMENT_ID).readUnlock();
         }
+    }
+
+    /**
+     * Evaluates an already-stored password against the current requirements. Returns the list of
+     * violations, or null if the password still meets them.
+     * <p>
+     * A null user id is passed deliberately. The checker runs its reuse-history checks when given a
+     * real id and either reuse policy is enabled, and at login the user's current password is by
+     * definition in their own credential history — so a real id would report the password as reused
+     * on every login, a violation the user cannot act on. Passing null is the checker's documented
+     * way to skip those checks, and it also keeps this call free of database access, which matters
+     * because authorizeUser runs on every Basic auth REST request.
+     */
+    protected List<String> getStoredPasswordViolations(String plainPassword, PasswordRequirements passwordRequirements) {
+        return PasswordRequirementsChecker.getInstance().doesPasswordMeetRequirements(null, plainPassword, passwordRequirements);
+    }
+
+    /**
+     * Formats requirement violations the way the clients already render them for the set-password
+     * path: a header followed by one bullet per violation.
+     */
+    public static String buildRequirementsMessage(List<String> violations) {
+        StringBuilder builder = new StringBuilder("Your password no longer meets the password requirements. Please change it now:");
+
+        for (String violation : violations) {
+            builder.append("\n - ").append(violation);
+        }
+
+        return builder.toString();
     }
 
     public boolean checkPassword(String plainPassword, String encryptedPassword) {
@@ -625,7 +669,18 @@ public class DefaultUserController extends UserController {
 
     private LoginStatus handleSecondaryAuthentication(String username, LoginStatus loginStatus, LoginRequirementsChecker loginRequirementsChecker, String serverURL) {
         if (loginStatus != null && extensionController.getMultiFactorAuthenticationPlugin() != null && (loginStatus.getStatus() == Status.SUCCESS || loginStatus.getStatus() == Status.SUCCESS_GRACE_PERIOD)) {
+            LoginStatus priorStatus = loginStatus;
             loginStatus = extensionController.getMultiFactorAuthenticationPlugin().authenticate(username, loginStatus, serverURL);
+
+            /*
+             * The plugin returns its own status rather than modifying the one it was given, so a
+             * grace period established above would be dropped for anyone using multi-factor auth.
+             * Restore it only when the plugin has finished and simply passed the login through: an
+             * ExtendedLoginStatus means it is mid-flow and is driving the client itself.
+             */
+            if (priorStatus.getStatus() == Status.SUCCESS_GRACE_PERIOD && loginStatus != null && loginStatus.getStatus() == Status.SUCCESS && !(loginStatus instanceof ExtendedLoginStatus)) {
+                loginStatus = new LoginStatus(Status.SUCCESS_GRACE_PERIOD, priorStatus.getMessage(), loginStatus.getUpdatedUsername());
+            }
         }
 
         // Only reset strikes if the final status is successful 

--- a/server/src/com/mirth/connect/server/util/PasswordRequirementsChecker.java
+++ b/server/src/com/mirth/connect/server/util/PasswordRequirementsChecker.java
@@ -34,6 +34,14 @@ public class PasswordRequirementsChecker implements Serializable {
 
     private static final String PASSWORD_IS_TOO_SHORT_MINIMUM_LENGTH = "Password is too short. Minimum length is %d characters";
 
+    /*
+     * The hardened defaults shipped since 26.6.0 already reject "admin" for length and character
+     * class. This check exists so the operator is told the actual problem rather than being sent
+     * down a list of composition failures. See IRT-1786.
+     */
+    private static final String DISALLOWED_PASSWORD = "admin";
+    private static final String PASSWORD_IS_NOT_ALLOWED = "\"%s\" is not allowed as a password";
+
     private static final String PASSWORD_MUST_CONTAIN_A_SPECIAL_CHARACTER = "Password must contain %d special character(s)";
     private static final String PASSWORD_MUST_NOT_CONTAIN_A_SPECIAL_CHARACTER = "Password must not contain a special character";
 
@@ -58,6 +66,8 @@ public class PasswordRequirementsChecker implements Serializable {
     private static final String PASSWORD_REUSE_PERIOD = "password.reuseperiod";
     private static final String PASSWORD_REUSE_LIMIT = "password.reuselimit";
     private static final String PASSWORD_ALLOW_USERNAME_ENUMERATION = "password.allowusernameenumeration";
+    private static final String PASSWORD_ENFORCE_AT_LOGIN = "password.enforceatlogin";
+    private static final String PASSWORD_RESTRICT_GRACE_SESSIONS = "password.restrictgracesessions";
 
     private static PasswordRequirementsChecker instance = null;
 
@@ -90,6 +100,8 @@ public class PasswordRequirementsChecker implements Serializable {
         passwordRequirements.setReusePeriod(securityProperties.getInt(PASSWORD_REUSE_PERIOD, 0));
         passwordRequirements.setReuseLimit(securityProperties.getInt(PASSWORD_REUSE_LIMIT, 0));
         passwordRequirements.setAllowUsernameEnumeration(securityProperties.getBoolean(PASSWORD_ALLOW_USERNAME_ENUMERATION, false));
+        passwordRequirements.setEnforceAtLogin(securityProperties.getBoolean(PASSWORD_ENFORCE_AT_LOGIN, true));
+        passwordRequirements.setRestrictGraceSessions(securityProperties.getBoolean(PASSWORD_RESTRICT_GRACE_SESSIONS, false));
         return passwordRequirements;
     }
 
@@ -103,6 +115,11 @@ public class PasswordRequirementsChecker implements Serializable {
      */
     public List<String> doesPasswordMeetRequirements(Integer userId, String plainPassword, PasswordRequirements passwordRequirements) {
         List<String> resultList = new ArrayList<String>();
+
+        if (StringUtils.equalsIgnoreCase(plainPassword, DISALLOWED_PASSWORD)) {
+            addResult(resultList, String.format(PASSWORD_IS_NOT_ALLOWED, DISALLOWED_PASSWORD));
+        }
+
         addResult(resultList, checkMinLower(plainPassword, passwordRequirements.getMinLower()));
         addResult(resultList, checkMinUpper(plainPassword, passwordRequirements.getMinUpper()));
         addResult(resultList, checkMinNumeric(plainPassword, passwordRequirements.getMinNumeric()));

--- a/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
+++ b/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
@@ -30,6 +30,10 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
     private static final Operation NORMAL_OPERATION = new Operation("getChannels", "Get channels", ExecuteType.SYNC, true);
     private static final Operation PASSWORD_OPERATION = new Operation("updateUserPassword", "Update a user's password", ExecuteType.SYNC, true);
 
+    /** The user ID ServletTestBase stores on the mock session. */
+    private static final Integer SESSION_USER_ID = 1;
+    private static final Integer OTHER_USER_ID = 2;
+
     @BeforeClass
     public static void setup() throws Exception {
         ServletTestBase.setup();
@@ -85,16 +89,71 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
     }
 
     /**
-     * The whole point of the restriction is that the user can still clear it.
+     * The whole point of the restriction is that the user can still clear it. The session user is
+     * ID 1, and the real request path resolves the target from the @CheckAuthorizedUserId
+     * parameter, so this goes through checkUserAuthorized rather than isUserAuthorized directly.
      */
     @Test
-    public void restrictedSessionMayStillChangeItsPassword() throws Exception {
+    public void restrictedSessionMayStillChangeItsOwnPassword() throws Exception {
         givenGraceRestrictedSession(true);
 
         MirthServlet servlet = newServlet();
         servlet.setOperation(PASSWORD_OPERATION);
 
-        assertTrue(servlet.isUserAuthorized(false));
+        servlet.checkUserAuthorized(SESSION_USER_ID, true);
+    }
+
+    /**
+     * The restriction exists so a confined login can repair its own password and nothing else.
+     * Allowing updateUserPassword by name alone let it reset any other account and log back in as
+     * that user unrestricted, which is the whole of IRT-1798.
+     */
+    @Test
+    public void restrictedSessionCannotChangeAnotherUsersPassword() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        try {
+            servlet.checkUserAuthorized(OTHER_USER_ID, true);
+            fail("Expected a grace-restricted session to be refused another user's password");
+        } catch (Throwable t) {
+            assertForbiddenException(t);
+        }
+    }
+
+    /**
+     * A self-only operation that arrives without a resolved target cannot show it is aimed at the
+     * caller, so it is refused rather than allowed on the strength of its name.
+     */
+    @Test
+    public void restrictedSessionIsDeniedPasswordChangeWithNoTargetUser() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        try {
+            servlet.isUserAuthorized(false);
+            fail("Expected a grace-restricted session to be refused a password change with no target");
+        } catch (Throwable t) {
+            assertForbiddenException(t);
+        }
+    }
+
+    /**
+     * The scoping is part of the restriction, not a new rule of its own. With the restriction off,
+     * a grace period must leave an administrator able to change anyone's password as before.
+     */
+    @Test
+    public void restrictionDisabledLeavesOtherUsersPasswordsReachable() throws Exception {
+        givenGraceRestrictedSession(false);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        servlet.checkUserAuthorized(OTHER_USER_ID, true);
     }
 
     /**

--- a/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
+++ b/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.server.api;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.mirth.connect.client.core.Operation;
+import com.mirth.connect.client.core.Operation.ExecuteType;
+import com.mirth.connect.model.PasswordRequirements;
+
+/**
+ * Covers the restriction placed on a login that is serving out a password grace period. See
+ * IRT-1791.
+ */
+public class MirthServletGracePeriodTest extends ServletTestBase {
+
+    private static final Operation NORMAL_OPERATION = new Operation("getChannels", "Get channels", ExecuteType.SYNC, true);
+    private static final Operation PASSWORD_OPERATION = new Operation("updateUserPassword", "Update a user's password", ExecuteType.SYNC, true);
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ServletTestBase.setup();
+    }
+
+    @After
+    public void tearDown() {
+        // The session and controller mocks are shared across the class
+        when(session.getAttribute("graceRestricted")).thenReturn(null);
+        when(configurationController.getPasswordRequirements()).thenReturn(null);
+    }
+
+    private void givenGraceRestrictedSession(boolean restrictionEnabled) {
+        when(session.getAttribute("graceRestricted")).thenReturn(Boolean.TRUE);
+
+        PasswordRequirements passwordRequirements = new PasswordRequirements();
+        passwordRequirements.setRestrictGraceSessions(restrictionEnabled);
+        when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
+    }
+
+    private MirthServlet newServlet() {
+        return new MirthServlet(request, sc, controllerFactory) {
+        };
+    }
+
+    /**
+     * The restriction ships off, so a grace period must not change what a login can do until an
+     * operator opts in.
+     */
+    @Test
+    public void restrictionDisabledLeavesGraceSessionAlone() throws Exception {
+        givenGraceRestrictedSession(false);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(NORMAL_OPERATION);
+
+        assertTrue(servlet.isUserAuthorized(false));
+    }
+
+    @Test
+    public void restrictedSessionIsDeniedOrdinaryOperations() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(NORMAL_OPERATION);
+
+        try {
+            servlet.isUserAuthorized(false);
+            fail("Expected a grace-restricted session to be refused");
+        } catch (Throwable t) {
+            assertForbiddenException(t);
+        }
+    }
+
+    /**
+     * The whole point of the restriction is that the user can still clear it.
+     */
+    @Test
+    public void restrictedSessionMayStillChangeItsPassword() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        assertTrue(servlet.isUserAuthorized(false));
+    }
+
+    /**
+     * getCurrentUser carries no self-scoping annotation, so it is refused unless it is allowed
+     * explicitly — and without it a client cannot learn which user it is changing the password for.
+     */
+    @Test
+    public void restrictedSessionMayStillIdentifyItself() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(new Operation("getCurrentUser", "Get current user", ExecuteType.SYNC, false));
+
+        assertTrue(servlet.isUserAuthorized(false));
+    }
+
+    /**
+     * Extension endpoints authorize through a separate method, so they need the same check.
+     */
+    @Test
+    public void restrictedSessionIsDeniedExtensionOperations() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(NORMAL_OPERATION);
+
+        try {
+            servlet.isUserAuthorizedForExtension("someextension", false);
+            fail("Expected a grace-restricted session to be refused for an extension operation");
+        } catch (Throwable t) {
+            assertForbiddenException(t);
+        }
+    }
+
+    @Test
+    public void unrestrictedSessionIsUnaffected() throws Exception {
+        when(session.getAttribute("graceRestricted")).thenReturn(null);
+
+        PasswordRequirements passwordRequirements = new PasswordRequirements();
+        passwordRequirements.setRestrictGraceSessions(true);
+        when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(NORMAL_OPERATION);
+
+        assertTrue(servlet.isUserAuthorized(false));
+    }
+
+    /**
+     * A password that meets requirements must not be treated as restricted just because the
+     * requirements object says restriction is available.
+     */
+    @Test
+    public void restrictionRequiresBothTheFlagAndTheSession() throws Exception {
+        when(session.getAttribute("graceRestricted")).thenReturn(Boolean.FALSE);
+
+        PasswordRequirements passwordRequirements = new PasswordRequirements();
+        passwordRequirements.setRestrictGraceSessions(true);
+        when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(NORMAL_OPERATION);
+
+        assertTrue(servlet.isUserAuthorized(false));
+    }
+}

--- a/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
+++ b/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
@@ -9,17 +9,32 @@
 
 package com.mirth.connect.server.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.mirth.connect.client.core.Operation;
 import com.mirth.connect.client.core.Operation.ExecuteType;
+import com.mirth.connect.client.core.api.Param;
+import com.mirth.connect.client.core.api.servlets.UserServletInterface;
+import com.mirth.connect.model.LoginStatus;
 import com.mirth.connect.model.PasswordRequirements;
+import com.mirth.connect.model.User;
+import com.mirth.connect.server.api.servlets.UserServlet;
 
 /**
  * Covers the restriction placed on a login that is serving out a password grace period. See
@@ -30,20 +45,40 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
     private static final Operation NORMAL_OPERATION = new Operation("getChannels", "Get channels", ExecuteType.SYNC, true);
     private static final Operation PASSWORD_OPERATION = new Operation("updateUserPassword", "Update a user's password", ExecuteType.SYNC, true);
 
-    /** The user ID ServletTestBase stores on the mock session. */
-    private static final Integer SESSION_USER_ID = 1;
-    private static final Integer OTHER_USER_ID = 2;
+    /**
+     * Deliberately outside the range java.lang.Integer caches (-128..127). isCurrentUser compares
+     * an Integer against an int, which unboxes and compares numerically — but were it ever to
+     * become an Integer-to-Integer comparison it would silently degrade to reference identity,
+     * which still holds for cached values and fails for everything above them. Small ids would let
+     * that regression pass here while denying every real deployment its own password change.
+     */
+    private static final Integer SESSION_USER_ID = 1000;
+    private static final Integer OTHER_USER_ID = 2000;
 
     @BeforeClass
     public static void setup() throws Exception {
         ServletTestBase.setup();
     }
 
+    @Before
+    public void overrideSessionUserId() {
+        when(session.getAttribute("user")).thenReturn(SESSION_USER_ID.toString());
+    }
+
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         // The session and controller mocks are shared across the class
         when(session.getAttribute("graceRestricted")).thenReturn(null);
         when(configurationController.getPasswordRequirements()).thenReturn(null);
+        when(session.getAttribute("user")).thenReturn("1");
+        when(session.getAttribute("authorized")).thenReturn(Boolean.TRUE);
+        when(request.getHeader("Authorization")).thenReturn(null);
+        when(userController.getUser(isNull(), anyString())).thenAnswer(invocation -> {
+            User user = new User();
+            user.setId(1);
+            user.setUsername(invocation.getArgument(1));
+            return user;
+        });
     }
 
     private void givenGraceRestrictedSession(boolean restrictionEnabled) {
@@ -51,6 +86,29 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
 
         PasswordRequirements passwordRequirements = new PasswordRequirements();
         passwordRequirements.setRestrictGraceSessions(restrictionEnabled);
+        when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
+    }
+
+    /**
+     * Drives initLogin down its Basic auth branch instead of the session branch. There is no
+     * session to mark, so the restriction is derived from the login result and applies to that one
+     * request — the path the reported bypass was originally demonstrated on.
+     */
+    private void givenGraceRestrictedBasicAuthRequest() throws Exception {
+        when(session.getAttribute("authorized")).thenReturn(null);
+        when(request.getHeader("Authorization")).thenReturn("Basic " + Base64.getEncoder().encodeToString("test:test".getBytes(StandardCharsets.US_ASCII)));
+        // initLogin passes a null serverURL, which anyString() would not match
+        when(userController.authorizeUser(anyString(), anyString(), isNull())).thenReturn(new LoginStatus(LoginStatus.Status.SUCCESS_GRACE_PERIOD, ""));
+        // initLogin looks the user up by name, so override the base stub's id of 1
+        when(userController.getUser(isNull(), anyString())).thenAnswer(invocation -> {
+            User user = new User();
+            user.setId(SESSION_USER_ID);
+            user.setUsername(invocation.getArgument(1));
+            return user;
+        });
+
+        PasswordRequirements passwordRequirements = new PasswordRequirements();
+        passwordRequirements.setRestrictGraceSessions(true);
         when(configurationController.getPasswordRequirements()).thenReturn(passwordRequirements);
     }
 
@@ -140,6 +198,68 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
         } catch (Throwable t) {
             assertForbiddenException(t);
         }
+    }
+
+    /**
+     * The bypass was originally demonstrated over Basic auth with no session at all, so the
+     * scoping has to hold on that path too and not just on the session flag.
+     */
+    @Test
+    public void restrictedBasicAuthRequestCannotChangeAnotherUsersPassword() throws Exception {
+        givenGraceRestrictedBasicAuthRequest();
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        try {
+            servlet.checkUserAuthorized(OTHER_USER_ID, true);
+            fail("Expected a grace-restricted Basic auth request to be refused another user's password");
+        } catch (Throwable t) {
+            assertForbiddenException(t);
+        }
+    }
+
+    @Test
+    public void restrictedBasicAuthRequestMayStillChangeItsOwnPassword() throws Exception {
+        givenGraceRestrictedBasicAuthRequest();
+
+        MirthServlet servlet = newServlet();
+        servlet.setOperation(PASSWORD_OPERATION);
+
+        servlet.checkUserAuthorized(SESSION_USER_ID, true);
+    }
+
+    /**
+     * The scoping only works because the invocation handler resolves the target user ID from
+     * {@code @CheckAuthorizedUserId} and hands it to checkUserAuthorized. Drop that annotation and
+     * the handler falls back to the no-argument overload, which leaves the target unknown — so
+     * every grace-restricted user would be refused their own password change and left with no way
+     * out of the restriction. Nothing else in the suite would notice, hence this check.
+     */
+    @Test
+    public void updateUserPasswordStillCarriesTheAnnotationTheScopingDependsOn() throws Exception {
+        Method implementation = UserServlet.class.getMethod("updateUserPassword", Integer.class, String.class);
+        CheckAuthorizedUserId annotation = implementation.getAnnotation(CheckAuthorizedUserId.class);
+
+        assertNotNull("UserServlet.updateUserPassword must keep @CheckAuthorizedUserId or the grace scoping cannot see its target", annotation);
+        assertTrue("updateUserPassword relies on isUserAuthorized running first, which auditCurrentUser = true guarantees", annotation.auditCurrentUser());
+
+        // The handler resolves the ID by matching paramName against the interface's @Param names
+        Method declaration = UserServletInterface.class.getMethod("updateUserPassword", Integer.class, String.class);
+        int userIdIndex = -1;
+
+        Annotation[][] parameterAnnotations = declaration.getParameterAnnotations();
+        for (int i = 0; i < parameterAnnotations.length && userIdIndex < 0; i++) {
+            for (Annotation parameterAnnotation : parameterAnnotations[i]) {
+                if (parameterAnnotation instanceof Param && ((Param) parameterAnnotation).value().equals(annotation.paramName())) {
+                    userIdIndex = i;
+                    break;
+                }
+            }
+        }
+
+        assertTrue("No @Param named \"" + annotation.paramName() + "\" on UserServletInterface.updateUserPassword, so the handler cannot resolve the target user ID", userIdIndex >= 0);
+        assertEquals("The resolved parameter must be the user ID", Integer.class, declaration.getParameterTypes()[userIdIndex]);
     }
 
     /**

--- a/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
+++ b/server/test/com/mirth/connect/server/api/MirthServletGracePeriodTest.java
@@ -112,6 +112,23 @@ public class MirthServletGracePeriodTest extends ServletTestBase {
     }
 
     /**
+     * Logging out only destroys the session. Refusing it would strand a user who declines the
+     * change with a session they can neither use nor end — and UserServlet.logout calls
+     * isUserAuthorized purely to audit, so a refusal there would abort before invalidating.
+     */
+    @Test
+    public void restrictedSessionMayStillLogOut() throws Exception {
+        givenGraceRestrictedSession(true);
+
+        for (String operationName : new String[] { "logout", "inactivityLogout" }) {
+            MirthServlet servlet = newServlet();
+            servlet.setOperation(new Operation(operationName, operationName, ExecuteType.SYNC, true));
+
+            assertTrue("\"" + operationName + "\" must remain available", servlet.isUserAuthorized(false));
+        }
+    }
+
+    /**
      * Extension endpoints authorize through a separate method, so they need the same check.
      */
     @Test

--- a/server/test/com/mirth/connect/server/controllers/DefaultUserControllerTest.java
+++ b/server/test/com/mirth/connect/server/controllers/DefaultUserControllerTest.java
@@ -12,6 +12,7 @@ package com.mirth.connect.server.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -46,6 +48,7 @@ import com.mirth.connect.client.core.ControllerException;
 import com.mirth.connect.model.Credentials;
 import com.mirth.connect.model.LoginStrike;
 import com.mirth.connect.model.LoginStatus;
+import com.mirth.connect.model.PasswordRequirements;
 import com.mirth.connect.model.User;
 import com.mirth.connect.server.util.SqlConfig;
 import com.mirth.connect.server.util.StatementLock;
@@ -1236,5 +1239,43 @@ public class DefaultUserControllerTest {
             // Other exceptions acceptable for extreme input
             assertNotNull("Should handle extreme input", e);
         }
+    }
+
+    // ========== LOGIN-TIME PASSWORD POLICY (IRT-1791) ==========
+
+    /**
+     * The login-time check must not run the reuse-history rules. A user's current password is
+     * always in their own credential history, so running them here would report every compliant
+     * password as reused on every login for any customer with a reuse policy configured — a
+     * violation the user has no way to clear. It would also add a database query to a method that
+     * runs on every Basic auth REST request.
+     */
+    @Test
+    public void testStoredPasswordViolations_IgnoresReuseHistory() {
+        // Both reuse rules on, which is what would trigger the history lookup
+        PasswordRequirements requirements = new PasswordRequirements(8, 1, 1, 1, 1, 0, 0, 0, 0, -1, -1, false);
+
+        List<String> violations = userController.getStoredPasswordViolations("Th1$isAtestTEST*#", requirements);
+
+        assertNull("A compliant password must not be reported as reused at login", violations);
+    }
+
+    @Test
+    public void testStoredPasswordViolations_ReportsNonCompliantPassword() {
+        PasswordRequirements requirements = new PasswordRequirements(8, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, false);
+
+        List<String> violations = userController.getStoredPasswordViolations("admin", requirements);
+
+        assertNotNull("A password failing the current rules must be reported", violations);
+        assertTrue(violations.contains("\"admin\" is not allowed as a password"));
+    }
+
+    @Test
+    public void testBuildRequirementsMessage_BulletsEachViolation() {
+        String message = DefaultUserController.buildRequirementsMessage(Arrays.asList("First problem", "Second problem"));
+
+        assertTrue(message.startsWith("Your password no longer meets the password requirements."));
+        assertTrue(message.contains("\n - First problem"));
+        assertTrue(message.contains("\n - Second problem"));
     }
 }

--- a/server/test/com/mirth/connect/server/util/PasswordRequirementsCheckerTest.java
+++ b/server/test/com/mirth/connect/server/util/PasswordRequirementsCheckerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Mirth Corporation. All rights reserved.
+ *
+ * http://www.mirthcorp.com
+ *
+ * The software in this package is published under the terms of the MPL license a copy of which has
+ * been included with this distribution in the LICENSE.txt file.
+ */
+
+package com.mirth.connect.server.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.junit.Test;
+
+import com.mirth.connect.model.PasswordRequirements;
+import com.mirth.connect.server.controllers.DefaultUserController;
+
+/**
+ * Covers the password rules and settings added for IRT-1786 and IRT-1791. The older
+ * PasswordRequirementsTest covers the character-class rules and is written against JUnit 3.
+ */
+public class PasswordRequirementsCheckerTest {
+
+    /**
+     * No composition rules at all, so "admin" can only be rejected by the explicit check.
+     */
+    private static PasswordRequirements noRules() {
+        return new PasswordRequirements(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
+    }
+
+    private static List<String> check(String plainPassword) {
+        return PasswordRequirementsChecker.getInstance().doesPasswordMeetRequirements(null, plainPassword, noRules());
+    }
+
+    @Test
+    public void adminIsRejectedRegardlessOfCase() {
+        for (String password : new String[] { "admin", "ADMIN", "AdMiN" }) {
+            List<String> violations = check(password);
+
+            assertNotNull("\"" + password + "\" should be rejected", violations);
+            assertEquals(1, violations.size());
+            assertEquals("\"admin\" is not allowed as a password", violations.get(0));
+        }
+    }
+
+    /**
+     * The rule is an exact match, not a substring one — rejecting every password containing "admin"
+     * would be a different and much broader rule than the ticket asked for.
+     */
+    @Test
+    public void passwordsMerelyContainingAdminAreAllowed() {
+        assertNull(check("administrator"));
+        assertNull(check("myadmin1"));
+        assertNull(check("admin1"));
+    }
+
+    @Test
+    public void unrelatedPasswordStillPasses() {
+        assertNull(check("Th1$isAtestTEST*#"));
+    }
+
+    /**
+     * "admin" also fails the shipped composition rules, so it must not be reported twice or mask
+     * the other violations.
+     */
+    @Test
+    public void adminIsReportedAlongsideCompositionFailures() {
+        PasswordRequirements shipped = new PasswordRequirements(8, 1, 1, 1, 1, 5, 1, 0, 0, 0, 0, false);
+        List<String> violations = PasswordRequirementsChecker.getInstance().doesPasswordMeetRequirements(null, "admin", shipped);
+
+        assertNotNull(violations);
+        assertTrue("Should name the disallowed password", violations.contains("\"admin\" is not allowed as a password"));
+        assertTrue("Should still report the length failure", violations.contains("Password is too short. Minimum length is 8 characters"));
+    }
+
+    @Test
+    public void loginEnforcementIsOnAndRestrictionIsOffByDefault() {
+        PasswordRequirements requirements = PasswordRequirementsChecker.getInstance().loadPasswordRequirements(new PropertiesConfiguration());
+
+        assertTrue("Stored passwords should be checked at login by default", requirements.isEnforceAtLogin());
+        assertFalse("Restricting grace sessions is a breaking change, so it must be opt in", requirements.isRestrictGraceSessions());
+    }
+
+    @Test
+    public void loginSettingsAreReadFromProperties() throws Exception {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty("password.enforceatlogin", "false");
+        properties.setProperty("password.restrictgracesessions", "true");
+
+        PasswordRequirements requirements = PasswordRequirementsChecker.getInstance().loadPasswordRequirements(properties);
+
+        assertFalse(requirements.isEnforceAtLogin());
+        assertTrue(requirements.isRestrictGraceSessions());
+    }
+
+    @Test
+    public void requirementsMessageListsEveryViolation() {
+        String message = DefaultUserController.buildRequirementsMessage(check("admin"));
+
+        assertTrue(message.startsWith("Your password no longer meets the password requirements."));
+        assertTrue(message.contains("\n - \"admin\" is not allowed as a password"));
+    }
+}


### PR DESCRIPTION
Closes the Core half of IRT-1786, part A of IRT-1791, and IRT-1798. The Web Admin half of IRT-1786 already merged as d70585a (BridgeLink-Web-UI #720); everything here is Core.

## The gap

Password requirements were enforced **only when a password was set**. `doesPasswordMeetRequirements` had exactly one production caller — the set-password path — and `authorizeUser` never called it. So when the defaults were hardened for 26.6.0 (`minlength=8`, one upper/lower/digit/special), every existing account kept its old password indefinitely, including passwords the server would now refuse to accept. Upgrading installs got the new policy in name only.

The existing expiration machinery does not cover this: it asks how *old* a password is, never whether it meets the rules, and it is dormant by default (`password.expiration = 0`).

## What changed

**Policy is evaluated at login.** Login is the one point where the server holds the plaintext. `authorizeUser` now checks it against the current requirements and returns `SUCCESS_GRACE_PERIOD` when it fails, so the user is prompted rather than locked out and API clients keep working. Governed by `password.enforceatlogin`, default **true**.

The check passes a **null user id** deliberately. The checker runs its reuse-history rules when given a real id and a reuse policy is enabled, and a user's current password is by definition in their own credential history — a real id would report every compliant password as "reused" on every login, a violation the user cannot clear. Null also keeps the call free of database access, which matters because `authorizeUser` runs on **every Basic auth REST request** (`MirthServlet:175`), not just interactive logins.

**`admin` is rejected by name.** The hardened defaults already reject it for length and character class, so this is a message-quality change — the operator is told the actual problem instead of reading four composition failures. It lives in the checker, not the servlet, because the checker is on every path.

**A server event is raised** when a login is allowed but the password fails policy. Stored passwords are hashed, so there is **no way to audit which accounts are affected** — this event is the only way to find them. It is dispatched from `UserServlet.login`, not `authorizeUser`, so a non-compliant polling account does not write an event every 60 seconds.

**Grace-period sessions can be confined.** They were fully privileged, so the change-password prompt was client-side UX only and could be ignored over REST — step 1 of the disclosure PoC. The session is now marked at login (and per-request on the Basic auth path) and refused for anything outside the operations needed to complete the change. Extension endpoints authorize through their own method, so the check is in both; the bypass user is unaffected; the 403 carries an explanation instead of being bare.

### Why the restriction ships off

`password.restrictgracesessions` defaults to **false**. It is a breaking change for automation — any account whose stored password fails the requirements starts getting 403 until rotated — and because passwords are hashed there is **no way to identify those accounts before they log in**. Note Fleet authenticates via `POST /users/_login` and caches a JSESSIONID, so it is on the session path and is not spared by any variant of the restriction.

Shipping it dormant gives operators one release in which the event above reveals affected accounts before the boundary that breaks them turns on. **IRT-1791 AC4 therefore holds at the shipped defaults**; enabling the flag deliberately overrides it. A follow-up should flip the default once operators have had a release to clean up.

### Collateral fixes

- **CLI** accepted only plain `SUCCESS`, so a weak-password user was told "Could not login to server" — a working credential misreported as a bad one. This breaks at the *shipped defaults*, so it was not optional.
- **Swing Administrator** handled the grace period *after* building the main window (`LoginPanel:567` vs `:610`). Under restriction every request made while loading would be refused before the user saw the prompt. The dialog now runs first, talking to the server directly since there is no Frame yet, and the login is abandoned if dismissed — which also makes it binding, where before Cancel left the user logged in having changed nothing.
- A fresh install hits both paths at once (the default password fails policy *and* it is the first login), so `FirstLoginDialog` no longer demands a password when one was already set during the same login.
- The **MFA plugin** returns its own `LoginStatus` rather than modifying the one it is given, which would silently drop the grace period. Restored when the plugin has finished and simply passed the login through.

## Verification

Full `ant -f mirth-build.xml` green: **220 test classes, 0 failures, 0 errors**. New tests mutation-checked — disabling the `admin` check fails 3, disabling the restriction fails 2.

- `PasswordRequirementsCheckerTest` (new, 7) — `admin` rejected in any case, exact-match not substring, defaults, property overrides
- `MirthServletGracePeriodTest` (new, 14) — restriction on/off, allowlisted operations, extension path, self-identification, and the IRT-1798 scoping cases below
- `DefaultUserControllerTest` (+3) — the reuse false-positive guard (AC5), non-compliant reporting, message format

Live against a dev server, both at shipped defaults and with the restriction enabled:

| Check | Result |
|---|---|
| `admin`/`admin` login | `SUCCESS_GRACE_PERIOD`, `"admin" is not allowed as a password` listed first |
| Privileged call, defaults | 200 session and Basic auth (AC4 holds) |
| Server event | Once per login; **not** raised per Basic-auth request |
| Privileged call, restriction on | **403 with explanation**, session and Basic auth |
| `getCurrentUser` / password change under restriction | 200 / 204 — the user can still fix it |
| Same session after change | 200, restriction lifted |
| Login with new password | plain `SUCCESS`; old password 401 |
| Reuse policy on, compliant password | plain `SUCCESS` — no false "cannot reuse" (AC5) |
| Setting password back to `admin` | rejected, named first |

## Not in this PR

- **`password == username`** (IRT-1791 part B, AC8/AC9). Dropped by decision — it needs a `username` parameter threaded through the checker, `UserController`, `UserServlet` and `UserServletInterface` (a REST contract change) for a rule that is near-redundant under the shipped defaults: for `password == username` to be reachable the username itself must be 8+ chars with upper, lower, digit and special.
- **Legacy Stripes `webadmin`** treats `SUCCESS_GRACE_PERIOD` as plain success with no prompt, so its users would see failures with no explanation when the restriction is enabled. Documented in the property comment, not fixed.

## Release note

`password.enforceatlogin` prompts non-compliant users at login starting this release. `password.restrictgracesessions` is available and **off**; enabling it will 403 non-compliant automation accounts, so rotate service-account passwords first.

---

## Review round 1 — two blockers found and fixed

An adversarial review of the first three commits turned up three defects, fixed in `22ce0cda`.

**Blocker: the Swing client could not log in at all on a default install.** `MirthDialog.setVisible` and `dispose` dereference `PlatformUI.MIRTH_FRAME`, which is only assigned inside `new Mirth(client)`. Moving the change-password dialog *ahead* of that call — the entire point of the client change — meant it NPE'd on `setVisible(true)`, and `LoginPanel` swallowed it as a generic connection error. Since the default `admin` password now fails policy, every fresh install would have hit this. Both calls are now null-guarded. Regression test: `MirthDialogNoFrameTest` (skips headless via `Assume`), which reproduces the exact NPE without the fix.

**Blocker: a restricted session could not log out.** `logout` and `inactivityLogout` are `@DontCheckAuthorized`, but call `isUserAuthorized()` purely to audit and ignore the answer — and that method now *throws* for a restricted session, aborting before `session.invalidate()`. A user who declined the change was left with a session they could neither use nor end, and the Swing abort path leaked it because it discards logout failures. Both operations are now in the allowlist; they only destroy the session. Regression test added.

**Minor:** the first-login register checkbox reset the password field to required, undoing the flag that prevents double-prompting.

### Known limitations, deliberately accepted

- **Two-leg MFA is not covered.** The second leg (`UserServlet:82`) authenticates through the plugin and never reaches `authorizeUser`, so for those deployments `enforceatlogin` is a no-op — no grace status and no login event, which also means the discovery mechanism shows nothing for MFA users. Needs its own ticket.
- **The restriction flag is per-session.** A user with two concurrent sessions who changes their password in one leaves the other restricted until it logs out and back in. Fails closed.
- **Extension operations are matched on the raw name.** A plugin operation literally named `checkUserPassword`, `getPasswordRequirements`, `getCurrentUser`, `logout`, or `inactivityLogout` would pass the grace gate, though it still faces its own extension permission check. (`updateUserPassword` is no longer in that set — see round 2.)

Full build re-run after the fixes: **221 test classes, 0 failures**.

---

## Review round 2 — IRT-1798, privilege escalation through the password write

The confinement had a hole that made it worse than useless where it was enabled: a grace-restricted login could set **any** user's password and then log in as that user with a session under no restriction at all. Fixed in `da979d1f`.

The allowlist matched on operation **name** only. `updateUserPassword` was on it so a confined user could repair their own password, but nothing scoped it to their own account. Reproduced over Basic auth with no session at all:

```
GET  /api/channels                          403   (restricted, as expected)
PUT  /api/users/2/password  "Pwned!Pass1"   204   <-- should be 403
POST /api/users/_login  victim/Pwned!Pass1  200   SUCCESS -> fully privileged
GET  /api/channels  (as admin)              403   attacker still restricted
```

`createUser` was correctly refused throughout, so the allowlist mechanism itself was sound — the hole was specifically the unscoped write.

**The fix.** The allowlist is split in two. Operations that name no user stay unscoped: `checkUserPassword` (it takes only a plaintext string), `getPasswordRequirements`, `getCurrentUser`, `logout`, `inactivityLogout`. `updateUserPassword` moves to a self-only set and is permitted only when the request targets the current user. The target id is recorded in `checkUserAuthorized(Integer, boolean)`, which already receives it from the `@CheckAuthorizedUserId` parameter and previously used it only for the "or it's yourself" fallback. A self-only operation that reaches the check **without** a resolved target is refused rather than allowed on the strength of its name — which also closes the extension-operation case noted above for this one operation.

Nothing changes at the shipped defaults: with `password.restrictgracesessions = false` a grace login keeps full privileges, including changing other users' passwords, on both the session and Basic auth paths.

Regression tests in `MirthServletGracePeriodTest` (7 -> 14): another user's id refused, own id still allowed, no-target refused, and the same cross-user write still permitted with the restriction off — each on both the session and the Basic auth path. Plus a check that `updateUserPassword` still carries `@CheckAuthorizedUserId` and that its `paramName` resolves to a real `@Param`: without the annotation the handler falls back to the no-argument overload, the target is unknown, and every grace-restricted user is refused their own password change, locking them out of the one operation that clears the restriction.

Fixture user ids sit deliberately outside the `Integer` cache, so the `Integer`-to-`int` comparison in `isCurrentUser` cannot silently degrade to reference identity and still pass.

Mutation-checked: reinstating `updateUserPassword` on the unscoped allowlist fails 3 of them, removing the annotation fails 1.

Re-verified live on a fresh install across both configurations — **31 checks, 0 failures**, where the pre-fix branch scored 30/1 with the bypass as the single failure. Specifically confirmed: the cross-user write is 403 on both the session and Basic auth paths and the victim's password is genuinely unchanged; a restricted session can still set its **own** password (204) and the same session is unrestricted immediately afterward with no re-login; logout from a restricted session still returns 204 and the session is genuinely dead; the entire shipped-defaults phase is unaffected.

### Correction to round 1

The round-1 note claiming that self-scoped operations annotated `auditCurrentUser = false` bypass the grace check, and that Web Admin depends on that to read the `firstlogin` preference, was **wrong on both halves** and has been removed. Observed: GET and PUT `/users/1/preferences/firstlogin` for **self** both return 403 under restriction, and Web Admin is blocked a step earlier at `GET /users` anyway.

The mechanism: `UserServlet` is constructed with `initLogin = false`, so `currentUserId` is still 0 when the `auditCurrentUser = false` branch evaluates `isCurrentUser(userId)` first. The self-check never matches and control always falls through to `isUserAuthorized()` and the grace check. Every `@CheckAuthorizedUserId` method in the codebase lives in `UserServlet`, so the exemption does not exist anywhere. It has been left non-existent rather than made real — nothing needs it, and relying on that `initLogin` accident would be fragile.

