### PR TITLE
fix(dynamic-lookup-gateway): dispatch JSON groups to importValuesJson in importGroup

### DIFF
--- a/custom-extensions/dynamic-lookup-gateway/server/src/main/java/com/mirth/connect/plugins/dynamiclookup/server/service/LookupService.java
+++ b/custom-extensions/dynamic-lookup-gateway/server/src/main/java/com/mirth/connect/plugins/dynamiclookup/server/service/LookupService.java
@@ -366,7 +366,12 @@ public class LookupService {
 
                 importValues = filtered;
             }
-            int count = valueDao.importValues(tableName, importValues);
+            int count;
+            if (isValueJson) {
+                count = valueDao.importValuesJson(tableName, importValues);
+            } else {
+                count = valueDao.importValues(tableName, importValues);
+            }
 
             // Audit
             recordAudit(groupId, tableName, "*", "IMPORT", null, count + " values imported", userId);


### PR DESCRIPTION
## Summary
- `LookupService.importGroup()` always called the non-JSON `valueDao.importValues`, even when the group's `valueType` is `JSON`, silently dropping inline values on import via the combined `POST /v1/lookups/groups/import` API path (IRT-1653, residual of IRT-699 — the earlier fix only covered TEXT groups).
- Adds the same `if (isValueJson) importValuesJson else importValues` branch that already exists in the sibling `importValues()` method (same file), so a single combined import call now works for both value types.

Note: neither the Swing WebAdmin client nor the Web UI client currently exercise this exact code path — both already work around it client-side by always sending `values: {}` to `importGroup` and importing values separately. This fix closes the underlying server defect so any direct API caller (scripts, integrations, future clients) doesn't hit silent data loss, and lets both clients eventually drop their two-step workaround.

## Test plan
- [ ] Import a JSON-typed lookup group via `POST /v1/lookups/groups/import` with `values` populated in the same request; confirm values are persisted (previously silently dropped).
- [ ] Import a TEXT-typed lookup group via the same endpoint; confirm behavior unchanged.
- [ ] Existing Swing/Web UI two-step import flows continue to work unaffected.